### PR TITLE
refactor(admin): 一括作成の生成ボタンをサーバー版のみに統一

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -192,7 +192,7 @@
 ### Lesson Schedule Enhancement Tasks
 ### レッスンスケジュール機能強化タスク
 
-- [ ] 12. Add bulk schedule creation feature
+- [x] 12. Add bulk schedule creation feature
   - File: app/Http/Controllers/Admin/LessonScheduleController.php (modify)
   - Add method for creating multiple schedules at once
   - Purpose: Allow creating recurring lesson schedules efficiently

--- a/app/Http/Controllers/Admin/LessonScheduleController.php
+++ b/app/Http/Controllers/Admin/LessonScheduleController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\BulkStoreLessonSchedulesRequest;
+use App\Http\Requests\Admin\GenerateRecurringLessonSchedulesRequest;
 use App\Http\Requests\StoreLessonScheduleRequest;
 use App\Http\Requests\UpdateLessonScheduleRequest;
 use App\Models\Lesson;
@@ -71,5 +73,77 @@ class LessonScheduleController extends Controller
         $lesson_schedule->delete();
 
         return redirect()->route('admin.lesson-schedules.index')->with('status', 'スケジュールを削除しました');
+    }
+
+    public function bulkCreate(): View
+    {
+        $lessons = Lesson::query()->orderBy('name')->get(['id', 'name']);
+
+        return view('admin.lesson_schedules.bulk-create', compact('lessons'));
+    }
+
+    public function bulkStore(BulkStoreLessonSchedulesRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $lessonId = $validated['lesson_id'];
+        $items = $validated['items'];
+
+        $payloads = [];
+        foreach ($items as $row) {
+            $payloads[] = [
+                'lesson_id' => $lessonId,
+                'start_datetime' => $row['start_datetime'],
+                'end_datetime' => $row['end_datetime'],
+                'current_bookings' => 0,
+                'is_active' => $row['is_active'] ?? true,
+            ];
+        }
+
+        LessonSchedule::query()->insert($payloads);
+
+        return redirect()->route('admin.lesson-schedules.index')->with('status', 'スケジュールを一括作成しました');
+    }
+
+    public function bulkGenerate(GenerateRecurringLessonSchedulesRequest $request): \Illuminate\Http\JsonResponse
+    {
+        $validated = $request->validated();
+        $startDate = \Illuminate\Support\Carbon::parse($validated['start_date'])->startOfDay();
+        $endDate = \Illuminate\Support\Carbon::parse($validated['end_date'])->startOfDay();
+        $startTime = $validated['start_time'];
+        $endTime = $validated['end_time'];
+        $intervalWeeks = (int) ($validated['interval_weeks'] ?? 1);
+        $weekdays = (array) $validated['weekdays']; // 0 (Sun) ... 6 (Sat)
+
+        $items = [];
+        foreach ($weekdays as $weekday) {
+            $cursor = $startDate->copy();
+            // advance to first matching weekday
+            while ($cursor->dayOfWeek !== (int) $weekday) {
+                $cursor->addDay();
+                if ($cursor->gt($endDate)) {
+                    continue 2;
+                }
+            }
+
+            // collect dates by interval weeks
+            for ($date = $cursor->copy(); $date->lte($endDate); $date->addWeeks($intervalWeeks)) {
+                $start = \Illuminate\Support\Carbon::parse($date->format('Y-m-d').' '.$startTime);
+                $end = \Illuminate\Support\Carbon::parse($date->format('Y-m-d').' '.$endTime);
+                $items[] = [
+                    'start_datetime' => $start->format('Y-m-d H:i:s'),
+                    'end_datetime' => $end->format('Y-m-d H:i:s'),
+                ];
+            }
+        }
+
+        // sort by start_datetime asc
+        usort($items, static function ($a, $b) {
+            return strcmp($a['start_datetime'], $b['start_datetime']);
+        });
+
+        return response()->json([
+            'items' => $items,
+            'count' => count($items),
+        ]);
     }
 }

--- a/app/Http/Controllers/Admin/LessonScheduleController.php
+++ b/app/Http/Controllers/Admin/LessonScheduleController.php
@@ -11,6 +11,7 @@ use App\Models\Lesson;
 use App\Models\LessonSchedule;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
 
 class LessonScheduleController extends Controller
 {
@@ -88,14 +89,17 @@ class LessonScheduleController extends Controller
         $lessonId = $validated['lesson_id'];
         $items = $validated['items'];
 
+        $now = now();
         $payloads = [];
         foreach ($items as $row) {
             $payloads[] = [
                 'lesson_id' => $lessonId,
-                'start_datetime' => $row['start_datetime'],
-                'end_datetime' => $row['end_datetime'],
+                'start_datetime' => Carbon::parse($row['start_datetime'])->format('Y-m-d H:i:s'),
+                'end_datetime' => Carbon::parse($row['end_datetime'])->format('Y-m-d H:i:s'),
                 'current_bookings' => 0,
                 'is_active' => $row['is_active'] ?? true,
+                'created_at' => $now,
+                'updated_at' => $now,
             ];
         }
 

--- a/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
+++ b/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
@@ -33,6 +33,21 @@ class BulkStoreLessonSchedulesRequest extends FormRequest
             foreach ($items as $idx => $row) {
                 if (is_array($row)) {
                     $items[$idx]['is_active'] = filter_var($row['is_active'] ?? true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
+                    // Normalize datetime-local (YYYY-MM-DDTHH:MM) or other formats to Y-m-d H:i:s
+                    if (! empty($row['start_datetime'])) {
+                        try {
+                            $items[$idx]['start_datetime'] = \Illuminate\Support\Carbon::parse(str_replace('T', ' ', (string) $row['start_datetime']))->format('Y-m-d H:i:s');
+                        } catch (\Throwable $e) {
+                            // keep original; validation will catch invalid date
+                        }
+                    }
+                    if (! empty($row['end_datetime'])) {
+                        try {
+                            $items[$idx]['end_datetime'] = \Illuminate\Support\Carbon::parse(str_replace('T', ' ', (string) $row['end_datetime']))->format('Y-m-d H:i:s');
+                        } catch (\Throwable $e) {
+                            // keep original; validation will catch invalid date
+                        }
+                    }
                 }
             }
             $this->merge(['items' => $items]);

--- a/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
+++ b/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class BulkStoreLessonSchedulesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    /**
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'lesson_id' => ['required', 'integer', Rule::exists('lessons', 'id')],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.start_datetime' => ['required', 'date', 'after_or_equal:now'],
+            'items.*.end_datetime' => ['required', 'date', 'after:start_datetime'],
+            'items.*.is_active' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $items = $this->input('items');
+        if (is_array($items)) {
+            foreach ($items as $idx => $row) {
+                if (is_array($row)) {
+                    $items[$idx]['is_active'] = filter_var($row['is_active'] ?? true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
+                }
+            }
+            $this->merge(['items' => $items]);
+        }
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'lesson_id' => 'レッスン',
+            'items' => 'スケジュール',
+            'items.*.start_datetime' => '開始日時',
+            'items.*.end_datetime' => '終了日時',
+            'items.*.is_active' => '有効フラグ',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
+++ b/app/Http/Requests/Admin/BulkStoreLessonSchedulesRequest.php
@@ -20,8 +20,8 @@ class BulkStoreLessonSchedulesRequest extends FormRequest
         return [
             'lesson_id' => ['required', 'integer', Rule::exists('lessons', 'id')],
             'items' => ['required', 'array', 'min:1'],
-            'items.*.start_datetime' => ['required', 'date', 'after_or_equal:now'],
-            'items.*.end_datetime' => ['required', 'date', 'after:start_datetime'],
+            'items.*.start_datetime' => ['required', 'date_format:Y-m-d H:i:s', 'after_or_equal:now'],
+            'items.*.end_datetime' => ['required', 'date_format:Y-m-d H:i:s', 'after:start_datetime'],
             'items.*.is_active' => ['sometimes', 'boolean'],
         ];
     }
@@ -32,7 +32,15 @@ class BulkStoreLessonSchedulesRequest extends FormRequest
         if (is_array($items)) {
             foreach ($items as $idx => $row) {
                 if (is_array($row)) {
-                    $items[$idx]['is_active'] = filter_var($row['is_active'] ?? true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
+                    if (array_key_exists('is_active', $row)) {
+                        $casted = filter_var($row['is_active'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                        if ($casted !== null) {
+                            $items[$idx]['is_active'] = $casted;
+                        }
+                        // invalid values are left as-is to be caught by validation
+                    } else {
+                        $items[$idx]['is_active'] = true; // default when not provided
+                    }
                     // Normalize datetime-local (YYYY-MM-DDTHH:MM) or other formats to Y-m-d H:i:s
                     if (! empty($row['start_datetime'])) {
                         try {

--- a/app/Http/Requests/Admin/GenerateRecurringLessonSchedulesRequest.php
+++ b/app/Http/Requests/Admin/GenerateRecurringLessonSchedulesRequest.php
@@ -21,9 +21,9 @@ class GenerateRecurringLessonSchedulesRequest extends FormRequest
             'end_date' => ['required', 'date', 'after_or_equal:start_date'],
             'start_time' => ['required', 'date_format:H:i'],
             'end_time' => ['required', 'date_format:H:i', 'after:start_time'],
-            'interval_weeks' => ['sometimes', 'integer', 'min:1'],
+            'interval_weeks' => ['required', 'integer', 'min:1'],
             'weekdays' => ['required', 'array', 'min:1'],
-            'weekdays.*' => ['integer', 'between:0,6'],
+            'weekdays.*' => ['integer', 'between:0,6', 'distinct'],
         ];
     }
 
@@ -31,16 +31,12 @@ class GenerateRecurringLessonSchedulesRequest extends FormRequest
     {
         $weekdays = $this->input('weekdays');
         if (is_array($weekdays)) {
-            $weekdays = array_values(array_unique(array_map('intval', $weekdays)));
+            $weekdays = array_values($weekdays);
         }
-        $interval = (int) ($this->input('interval_weeks') ?? 1);
-        if ($interval < 1) {
-            $interval = 1;
+        if (! $this->has('interval_weeks')) {
+            $this->merge(['interval_weeks' => 1]);
         }
-        $this->merge([
-            'weekdays' => $weekdays,
-            'interval_weeks' => $interval,
-        ]);
+        $this->merge(['weekdays' => $weekdays]);
     }
 
     public function attributes(): array
@@ -52,6 +48,7 @@ class GenerateRecurringLessonSchedulesRequest extends FormRequest
             'end_time' => '終了時刻',
             'interval_weeks' => '間隔（週）',
             'weekdays' => '曜日',
+            'weekdays.*' => '曜日（各要素）',
         ];
     }
 }

--- a/app/Http/Requests/Admin/GenerateRecurringLessonSchedulesRequest.php
+++ b/app/Http/Requests/Admin/GenerateRecurringLessonSchedulesRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GenerateRecurringLessonSchedulesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    /**
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date', 'after_or_equal:start_date'],
+            'start_time' => ['required', 'date_format:H:i'],
+            'end_time' => ['required', 'date_format:H:i', 'after:start_time'],
+            'interval_weeks' => ['sometimes', 'integer', 'min:1'],
+            'weekdays' => ['required', 'array', 'min:1'],
+            'weekdays.*' => ['integer', 'between:0,6'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $weekdays = $this->input('weekdays');
+        if (is_array($weekdays)) {
+            $weekdays = array_values(array_unique(array_map('intval', $weekdays)));
+        }
+        $interval = (int) ($this->input('interval_weeks') ?? 1);
+        if ($interval < 1) {
+            $interval = 1;
+        }
+        $this->merge([
+            'weekdays' => $weekdays,
+            'interval_weeks' => $interval,
+        ]);
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'start_date' => '期間（開始日）',
+            'end_date' => '期間（終了日）',
+            'start_time' => '開始時刻',
+            'end_time' => '終了時刻',
+            'interval_weeks' => '間隔（週）',
+            'weekdays' => '曜日',
+        ];
+    }
+}

--- a/resources/views/admin/lesson_schedules/bulk-create.blade.php
+++ b/resources/views/admin/lesson_schedules/bulk-create.blade.php
@@ -1,0 +1,228 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">レッスンスケジュール一括作成</h2>
+    </x-slot>
+
+    <div class="container mx-auto px-4 py-6">
+        <form method="POST" action="{{ route('admin.lesson-schedules.bulk.store') }}" class="space-y-4">
+            @csrf
+
+            <div>
+                <label class="block text-sm font-medium">レッスン</label>
+                <select name="lesson_id" class="border rounded w-full p-2" required>
+                    <option value="" disabled selected>選択してください</option>
+                    @foreach ($lessons as $lesson)
+                        <option value="{{ $lesson->id }}" @selected(old('lesson_id') == $lesson->id)>{{ $lesson->name }} (ID:{{ $lesson->id }})</option>
+                    @endforeach
+                </select>
+                @error('lesson_id') <div class="text-red-600 text-sm">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="rounded border p-4 space-y-3">
+                <h3 class="font-semibold">繰り返し生成（任意）</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium">期間（開始）</label>
+                        <input type="date" id="rec-start-date" class="border rounded w-full p-2">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium">期間（終了）</label>
+                        <input type="date" id="rec-end-date" class="border rounded w-full p-2">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium">開始時刻</label>
+                        <input type="time" id="rec-start-time" class="border rounded w-full p-2">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium">終了時刻</label>
+                        <input type="time" id="rec-end-time" class="border rounded w-full p-2">
+                    </div>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-1">曜日</label>
+                    <div class="flex flex-wrap gap-3">
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="1"><span>月</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="2"><span>火</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="3"><span>水</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="4"><span>木</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="5"><span>金</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="6"><span>土</span></label>
+                        <label class="inline-flex items-center gap-1"><input type="checkbox" class="rec-weekday" value="0"><span>日</span></label>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+                    <div>
+                        <label class="block text-sm font-medium">間隔（週）</label>
+                        <input type="number" id="rec-interval" class="border rounded w-full p-2" min="1" value="1">
+                    </div>
+                    <div class="md:col-span-2 flex gap-2">
+                        <button type="button" id="rec-generate-server" class="px-4 py-2 border rounded">行を自動生成</button>
+                        <span class="text-sm text-gray-600 self-center">例：毎週火曜を選べば、期間内の火曜分が追加されます</span>
+                    </div>
+                </div>
+            </div>
+
+            <div id="items" class="space-y-4">
+                @php $oldItems = old('items', [['start_datetime' => '', 'end_datetime' => '', 'is_active' => true]]); @endphp
+                @foreach ($oldItems as $i => $item)
+                    <div class="border rounded p-4 space-y-3 item-row">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium">開始日時</label>
+                                <input type="datetime-local" name="items[{{ $i }}][start_datetime]" class="border rounded w-full p-2" value="{{ $item['start_datetime'] }}" required>
+                                @error("items.$i.start_datetime") <div class="text-red-600 text-sm">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium">終了日時</label>
+                                <input type="datetime-local" name="items[{{ $i }}][end_datetime]" class="border rounded w-full p-2" value="{{ $item['end_datetime'] }}" required>
+                                @error("items.$i.end_datetime") <div class="text-red-600 text-sm">{{ $message }}</div> @enderror
+                            </div>
+                        </div>
+                        <div>
+                            <label class="inline-flex items-center">
+                                <input type="hidden" name="items[{{ $i }}][is_active]" value="0">
+                                <input type="checkbox" name="items[{{ $i }}][is_active]" value="1" @checked($item['is_active'])>
+                                <span class="ml-2">有効</span>
+                            </label>
+                            @error("items.$i.is_active") <div class="text-red-600 text-sm">{{ $message }}</div> @enderror
+                        </div>
+                        <div class="flex justify-end">
+                            <button type="button" class="px-3 py-1 border rounded text-red-700 remove-row">行を削除</button>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="flex gap-2">
+                <button type="button" id="add-row" class="px-4 py-2 border rounded">行を追加</button>
+                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">一括作成</button>
+                <a href="{{ route('admin.lesson-schedules.index') }}" class="px-4 py-2 border rounded">一覧へ戻る</a>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const container = document.getElementById('items');
+            const addBtn = document.getElementById('add-row');
+            const recGenerateServerBtn = document.getElementById('rec-generate-server');
+            const recStartDate = document.getElementById('rec-start-date');
+            const recEndDate = document.getElementById('rec-end-date');
+            const recStartTime = document.getElementById('rec-start-time');
+            const recEndTime = document.getElementById('rec-end-time');
+            const recInterval = document.getElementById('rec-interval');
+
+            addBtn.addEventListener('click', () => {
+                const index = container.querySelectorAll('.item-row').length;
+                const wrapper = document.createElement('div');
+                wrapper.className = 'border rounded p-4 space-y-3 item-row';
+                wrapper.innerHTML = `
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium">開始日時</label>
+                            <input type="datetime-local" name="items[${index}][start_datetime]" class="border rounded w-full p-2" required>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium">終了日時</label>
+                            <input type="datetime-local" name="items[${index}][end_datetime]" class="border rounded w-full p-2" required>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="inline-flex items-center">
+                            <input type="hidden" name="items[${index}][is_active]" value="0">
+                            <input type="checkbox" name="items[${index}][is_active]" value="1" checked>
+                            <span class="ml-2">有効</span>
+                        </label>
+                    </div>
+                    <div class="flex justify-end">
+                        <button type="button" class="px-3 py-1 border rounded text-red-700 remove-row">行を削除</button>
+                    </div>
+                `;
+                container.appendChild(wrapper);
+            });
+
+            container.addEventListener('click', (e) => {
+                if (e.target.classList.contains('remove-row')) {
+                    const row = e.target.closest('.item-row');
+                    row.remove();
+                }
+            });
+
+
+
+            recGenerateServerBtn.addEventListener('click', async () => {
+                const sDate = recStartDate.value;
+                const eDate = recEndDate.value;
+                const startTime = recStartTime.value;
+                const endTime = recEndTime.value;
+                const intervalWeeks = Math.max(1, Number(recInterval.value || 1));
+                const weekdayCheckboxes = Array.from(document.querySelectorAll('.rec-weekday'));
+                const weekdays = weekdayCheckboxes.filter(cb => cb.checked).map(cb => Number(cb.value));
+
+                if (!sDate || !eDate || !startTime || !endTime || weekdays.length === 0) {
+                    alert('期間、曜日、開始・終了時刻をすべて指定してください。');
+                    return;
+                }
+
+                const payload = {
+                    start_date: sDate,
+                    end_date: eDate,
+                    start_time: startTime,
+                    end_time: endTime,
+                    interval_weeks: intervalWeeks,
+                    weekdays,
+                };
+
+                try {
+                    const res = await fetch("{{ route('admin.lesson-schedules.bulk.generate') }}", {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': document.querySelector('input[name="_token"]').value,
+                            'Accept': 'application/json',
+                        },
+                        body: JSON.stringify(payload),
+                    });
+                    if (!res.ok) {
+                        const txt = await res.text();
+                        throw new Error(txt || '生成に失敗しました');
+                    }
+                    const data = await res.json();
+                    const items = Array.isArray(data.items) ? data.items : [];
+                    for (const item of items) {
+                        const index = container.querySelectorAll('.item-row').length;
+                        const wrapper = document.createElement('div');
+                        wrapper.className = 'border rounded p-4 space-y-3 item-row';
+                        // Convert Y-m-d H:i:s -> datetime-local
+                        const toLocal = (s) => s.replace(' ', 'T').slice(0, 16);
+                        wrapper.innerHTML = `
+                            <div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\">
+                                <div>
+                                    <label class=\"block text-sm font-medium\">開始日時</label>
+                                    <input type=\"datetime-local\" name=\"items[${index}][start_datetime]\" class=\"border rounded w-full p-2\" value=\"${toLocal(item.start_datetime)}\" required>
+                                </div>
+                                <div>
+                                    <label class=\"block text-sm font-medium\">終了日時</label>
+                                    <input type=\"datetime-local\" name=\"items[${index}][end_datetime]\" class=\"border rounded w-full p-2\" value=\"${toLocal(item.end_datetime)}\" required>
+                                </div>
+                            </div>
+                            <div>
+                                <label class=\"inline-flex items-center\">
+                                    <input type=\"hidden\" name=\"items[${index}][is_active]\" value=\"0\">
+                                    <input type=\"checkbox\" name=\"items[${index}][is_active]\" value=\"1\" checked>
+                                    <span class=\"ml-2\">有効</span>
+                                </label>
+                            </div>
+                            <div class=\"flex justify-end\">
+                                <button type=\"button\" class=\"px-3 py-1 border rounded text-red-700 remove-row\">行を削除</button>
+                            </div>
+                        `;
+                        container.appendChild(wrapper);
+                    }
+                } catch (err) {
+                    alert(err.message || '生成に失敗しました');
+                }
+            });
+        });
+    </script>
+</x-app-layout>

--- a/resources/views/admin/lesson_schedules/index.blade.php
+++ b/resources/views/admin/lesson_schedules/index.blade.php
@@ -5,7 +5,10 @@
 
     <div class="container mx-auto px-4 py-6">
         <div class="flex justify-between items-center mb-4">
-            <a href="{{ route('admin.lesson-schedules.create') }}" class="bg-blue-600 text-white px-4 py-2 rounded">新規作成</a>
+            <div class="space-x-2">
+                <a href="{{ route('admin.lesson-schedules.create') }}" class="bg-blue-600 text-white px-4 py-2 rounded">新規作成</a>
+                <a href="{{ route('admin.lesson-schedules.bulk.create') }}" class="bg-indigo-600 text-white px-4 py-2 rounded">一括作成</a>
+            </div>
         </div>
 
     @if (session('status'))
@@ -63,5 +66,3 @@
     </div>
     </div>
 </x-app-layout>
-
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,16 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Admin: lesson schedules CRUD
         Route::resource('lesson-schedules', LessonScheduleController::class);
 
+        // Admin: lesson schedules bulk create
+        Route::get('lesson-schedules/bulk/create', [LessonScheduleController::class, 'bulkCreate'])
+            ->name('lesson-schedules.bulk.create');
+        Route::post('lesson-schedules/bulk', [LessonScheduleController::class, 'bulkStore'])
+            ->name('lesson-schedules.bulk.store');
+
+        // Admin: lesson schedules recurrence generator (server-side)
+        Route::post('lesson-schedules/bulk/generate', [LessonScheduleController::class, 'bulkGenerate'])
+            ->name('lesson-schedules.bulk.generate');
+
         // Admin: notification templates CRUD
         Route::resource('notification-templates', NotificationTemplateController::class);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,9 +42,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Admin: lessons CRUD
         Route::resource('lessons', LessonController::class);
 
-        // Admin: lesson schedules CRUD
-        Route::resource('lesson-schedules', LessonScheduleController::class);
-
         // Admin: lesson schedules bulk create
         Route::get('lesson-schedules/bulk/create', [LessonScheduleController::class, 'bulkCreate'])
             ->name('lesson-schedules.bulk.create');
@@ -54,6 +51,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Admin: lesson schedules recurrence generator (server-side)
         Route::post('lesson-schedules/bulk/generate', [LessonScheduleController::class, 'bulkGenerate'])
             ->name('lesson-schedules.bulk.generate');
+
+        // Admin: lesson schedules CRUD
+        Route::resource('lesson-schedules', LessonScheduleController::class);
 
         // Admin: notification templates CRUD
         Route::resource('notification-templates', NotificationTemplateController::class);

--- a/tests/Feature/Admin/LessonScheduleBulkGenerateTest.php
+++ b/tests/Feature/Admin/LessonScheduleBulkGenerateTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    \Carbon\Carbon::setTestNow('2025-01-01 12:00:00');
+});
+
+afterEach(function () {
+    \Carbon\Carbon::setTestNow();
+});
+
+it('validates generator payload', function () {
+    $admin = adminUser();
+    $this->actingAs($admin)
+        ->postJson(route('admin.lesson-schedules.bulk.generate'), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['start_date', 'end_date', 'start_time', 'end_time', 'weekdays']);
+});
+
+it('generates weekly tuesdays within range', function () {
+    $admin = adminUser();
+
+    $payload = [
+        'start_date' => '2025-01-01', // Wed
+        'end_date' => '2025-01-31',
+        'start_time' => '10:00',
+        'end_time' => '11:00',
+        'interval_weeks' => 1,
+        'weekdays' => [2], // Tue
+    ];
+
+    $res = $this->actingAs($admin)
+        ->postJson(route('admin.lesson-schedules.bulk.generate'), $payload)
+        ->assertOk()
+        ->json();
+
+    expect($res['count'])->toBeGreaterThan(0);
+    foreach ($res['items'] as $item) {
+        expect($item['start_datetime'])->toContain('10:00:00');
+        expect($item['end_datetime'])->toContain('11:00:00');
+    }
+});

--- a/tests/Feature/Admin/LessonScheduleBulkGenerateTest.php
+++ b/tests/Feature/Admin/LessonScheduleBulkGenerateTest.php
@@ -38,6 +38,14 @@ it('generates weekly tuesdays within range', function () {
         ->json();
 
     expect($res['count'])->toBeGreaterThan(0);
+    // ensure ascending order by start_datetime
+    $startTimes = array_column($res['items'], 'start_datetime');
+    $sortedStartTimes = $startTimes;
+    sort($sortedStartTimes, SORT_STRING);
+    expect($startTimes)->toBe($sortedStartTimes);
+
+    // ensure no duplicate start_datetime
+    expect(count($startTimes))->toBe(count(array_unique($startTimes)));
     foreach ($res['items'] as $item) {
         expect($item['start_datetime'])->toContain('10:00:00');
         expect($item['end_datetime'])->toContain('11:00:00');

--- a/tests/Feature/Admin/LessonScheduleBulkTest.php
+++ b/tests/Feature/Admin/LessonScheduleBulkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\Lesson;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    \Carbon\Carbon::setTestNow('2025-01-01 12:00:00');
+});
+
+afterEach(function () {
+    \Carbon\Carbon::setTestNow();
+});
+
+it('admin can view bulk create page', function () {
+    $admin = adminUser();
+
+    $this->actingAs($admin)
+        ->get(route('admin.lesson-schedules.bulk.create'))
+        ->assertOk()
+        ->assertSee('レッスンスケジュール一括作成');
+});
+
+it('admin can bulk store schedules', function () {
+    $admin = adminUser();
+    $lesson = Lesson::factory()->create();
+
+    $payload = [
+        'lesson_id' => $lesson->id,
+        'items' => [
+            [
+                'start_datetime' => now()->addDays(1)->format('Y-m-d H:i:s'),
+                'end_datetime' => now()->addDays(1)->addHour()->format('Y-m-d H:i:s'),
+                'is_active' => true,
+            ],
+            [
+                'start_datetime' => now()->addDays(8)->format('Y-m-d H:i:s'),
+                'end_datetime' => now()->addDays(8)->addHour()->format('Y-m-d H:i:s'),
+                'is_active' => false,
+            ],
+        ],
+    ];
+
+    $this->actingAs($admin)
+        ->post(route('admin.lesson-schedules.bulk.store'), $payload)
+        ->assertRedirect(route('admin.lesson-schedules.index'))
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('lesson_schedules', [
+        'lesson_id' => $lesson->id,
+        'start_datetime' => $payload['items'][0]['start_datetime'],
+        'end_datetime' => $payload['items'][0]['end_datetime'],
+        'is_active' => 1,
+    ]);
+    $this->assertDatabaseHas('lesson_schedules', [
+        'lesson_id' => $lesson->id,
+        'start_datetime' => $payload['items'][1]['start_datetime'],
+        'end_datetime' => $payload['items'][1]['end_datetime'],
+        'is_active' => 0,
+    ]);
+});
+
+it('bulk store requires valid payload', function () {
+    $admin = adminUser();
+    $this->actingAs($admin)
+        ->post(route('admin.lesson-schedules.bulk.store'), [])
+        ->assertSessionHasErrors(['lesson_id', 'items']);
+});

--- a/tests/Feature/Admin/LessonScheduleBulkTest.php
+++ b/tests/Feature/Admin/LessonScheduleBulkTest.php
@@ -61,6 +61,50 @@ it('admin can bulk store schedules', function () {
     ]);
 });
 
+it('admin can bulk store schedules with datetime-local format', function () {
+    $admin = adminUser();
+    $lesson = Lesson::factory()->create();
+
+    $start1 = now()->addDays(2)->format('Y-m-d\TH:i');
+    $end1 = now()->addDays(2)->addHour()->format('Y-m-d\TH:i');
+    $start2 = now()->addDays(9)->format('Y-m-d\TH:i');
+    $end2 = now()->addDays(9)->addHour()->format('Y-m-d\TH:i');
+
+    $payload = [
+        'lesson_id' => $lesson->id,
+        'items' => [
+            [
+                'start_datetime' => $start1,
+                'end_datetime' => $end1,
+                'is_active' => true,
+            ],
+            [
+                'start_datetime' => $start2,
+                'end_datetime' => $end2,
+                'is_active' => false,
+            ],
+        ],
+    ];
+
+    $this->actingAs($admin)
+        ->post(route('admin.lesson-schedules.bulk.store'), $payload)
+        ->assertRedirect(route('admin.lesson-schedules.index'))
+        ->assertSessionHasNoErrors();
+
+    $this->assertDatabaseHas('lesson_schedules', [
+        'lesson_id' => $lesson->id,
+        'start_datetime' => \Carbon\Carbon::parse(str_replace('T', ' ', $start1))->format('Y-m-d H:i:s'),
+        'end_datetime' => \Carbon\Carbon::parse(str_replace('T', ' ', $end1))->format('Y-m-d H:i:s'),
+        'is_active' => 1,
+    ]);
+    $this->assertDatabaseHas('lesson_schedules', [
+        'lesson_id' => $lesson->id,
+        'start_datetime' => \Carbon\Carbon::parse(str_replace('T', ' ', $start2))->format('Y-m-d H:i:s'),
+        'end_datetime' => \Carbon\Carbon::parse(str_replace('T', ' ', $end2))->format('Y-m-d H:i:s'),
+        'is_active' => 0,
+    ]);
+});
+
 it('bulk store requires valid payload', function () {
     $admin = adminUser();
     $this->actingAs($admin)


### PR DESCRIPTION
- フロントJS版の生成ボタンとロジックを削除
- サーバーAPI版を「行を自動生成」にリネーム
- テスト・保守性を重視した実装に統一

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - レッスンスケジュールの一括作成を追加。複数行の追加/削除、各行の有効/無効設定、保存時の成功メッセージ。
- 自動生成
  - 期間・曜日・時間帯・週間隔から繰り返しスケジュールを生成し、開始日時でソートしてJSONで返却。
- UI
  - 一覧に「一括作成」ボタンを追加し、専用フォームで生成・編集（datetime-local対応）を実行可能。
- ルーティング
  - 一括表示・保存・生成のエンドポイントを追加。
- テスト
  - バリデーション、生成、保存の機能テストを追加・拡充。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->