### PR TITLE
feat: Task 19 - Stripe API keys and webhook configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,8 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Stripe Configuration
+STRIPE_KEY=pk_test_your_publishable_key_here
+STRIPE_SECRET=sk_test_your_secret_key_here
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here

--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -168,7 +168,7 @@
   - Dependencies: None / 依存関係: なし
   - Estimated time: 15 minutes / 推定時間: 15分
 
-- [ ] 19. Configure Stripe API keys and webhooks / Stripe APIキーとWebhookを設定
+- [x] 19. Configure Stripe API keys and webhooks / Stripe APIキーとWebhookを設定
   - File: .env (modify), config/services.php (modify) / ファイル: .env (修正), config/services.php (修正)
   - Add STRIPE_KEY, STRIPE_SECRET, STRIPE_WEBHOOK_SECRET / STRIPE_KEY, STRIPE_SECRET, STRIPE_WEBHOOK_SECRETを追加
   - Configure CSRF exclusion for stripe/* routes in bootstrap/app.php / bootstrap/app.phpでstripe/*ルートのCSRF除外を設定

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->validateCsrfTokens(except: [
+            '/stripe/webhook',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/migrations/2025_09_15_165009_create_customer_columns.php
+++ b/database/migrations/2025_09_15_165009_create_customer_columns.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('stripe_id')->nullable()->index();
+            $table->string('pm_type')->nullable();
+            $table->string('pm_last_four', 4)->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex([
+                'stripe_id',
+            ]);
+
+            $table->dropColumn([
+                'stripe_id',
+                'pm_type',
+                'pm_last_four',
+                'trial_ends_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_09_15_165010_create_subscriptions_table.php
+++ b/database/migrations/2025_09_15_165010_create_subscriptions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('type');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_status');
+            $table->string('stripe_price')->nullable();
+            $table->integer('quantity')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'stripe_status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/database/migrations/2025_09_15_165010_create_subscriptions_table.php
+++ b/database/migrations/2025_09_15_165010_create_subscriptions_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id');
-            $table->string('type');
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
             $table->string('stripe_id')->unique();
             $table->string('stripe_status');
             $table->string('stripe_price')->nullable();

--- a/database/migrations/2025_09_15_165011_create_subscription_items_table.php
+++ b/database/migrations/2025_09_15_165011_create_subscription_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscription_id');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_product');
+            $table->string('stripe_price');
+            $table->integer('quantity')->nullable();
+            $table->timestamps();
+
+            $table->index(['subscription_id', 'stripe_price']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_items');
+    }
+};

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -286,6 +286,9 @@ system_settings (システム設定) ✅
 
 ### Phase 2: 月謝システム
 - [x] Laravel Cashierインストール・設定
+  - [ ] Cashierマイグレーション公開: `php artisan vendor:publish --tag="cashier-migrations"`
+  - [ ] マイグレーション実行: `php artisan migrate`
+  - [ ] Stripeキー設定: `.env(.example)` に `STRIPE_KEY`, `STRIPE_SECRET`, `STRIPE_WEBHOOK_SECRET` を追加
 - [ ] Stripe Products & Prices設定
 - [ ] Stripe Checkout統合
 - [ ] Webhook設定・自動同期
@@ -309,7 +312,7 @@ system_settings (システム設定) ✅
 ### Phase 3.5: セキュリティ強化
 - [ ] 包括的な入力バリデーション実装
 - [ ] 重要なエンドポイントへのレート制限追加
-- [ ] CSRF保護検証実装（Webhook用CSRF除外設定含む）
+- [ ] CSRF保護検証実装（Webhook用CSRF除外設定は /stripe/webhook のみ）
 
 ### Phase 4: ユーザー向けUI基盤構築
 - [ ] ユーザー画面UI（モバイルファースト）


### PR DESCRIPTION
- Publish Cashier migrations for subscription tables
- Add Stripe keys to .env.example (STRIPE_KEY, STRIPE_SECRET, STRIPE_WEBHOOK_SECRET)
- Configure CSRF exclusion for /stripe/webhook in bootstrap/app.php
- Test webhook functionality with Stripe CLI (successful)
- Update project documentation with detailed Stripe setup steps

Refs: Task 19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - Stripe決済・サブスクリプションの基盤を追加（Webhook受信のCSRF除外を含む）
  - ユーザーの支払い・サブスクリプション情報を保存するためのDB構造を追加
- ドキュメント
  - Cashier導入手順とマイグレーション実行、Stripeキー設定を追記
  - WebhookのCSRF除外対象を「/stripe/webhook」に明確化
- チョア
  - タスク一覧でStripe関連設定を完了に更新
  - 環境変数サンプルにStripeキーを追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->