### PR TITLE
feat: Task 28 - カテゴリー別サブスクリプション管理を実装

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -267,7 +267,7 @@
 ### Advanced Subscription Management Tasks
 ### 高度なサブスクリプション管理タスク
 
-- [ ] 28. Implement category-based subscription management / カテゴリー別サブスクリプション管理を実装
+- [x] 28. Implement category-based subscription management / カテゴリー別サブスクリプション管理を実装
   - File: app/Models/User.php (modify), app/Models/UserSubscription.php (modify) / ファイル: app/Models/User.php (修正), app/Models/UserSubscription.php (修正)
   - **Architecture Design / アーキテクチャ設計**:
     - Two-layer subscription management: Stripe Layer (subscriptions table) vs Application Layer (user_subscriptions table) / 二層サブスクリプション管理: Stripe Layer (subscriptions table) vs Application Layer (user_subscriptions table)

--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -315,7 +315,7 @@
   - File: database/migrations/ (new migration files) / ファイル: database/migrations/ (新規マイグレーションファイル)
   - Add remaining_lessons column to user_subscriptions table / user_subscriptionsテーブルにremaining_lessonsカラムを追加
   - Create plan_switch_logs table for statistics / 統計用plan_switch_logsテーブルを作成
-  - Add performance indexes: (user_id, status, payment_status), (user_id, current_period_start DESC), (user_id, lesson_schedule_id) / パフォーマンスインデックス追加: (user_id, status, payment_status), (user_id, current_period_start DESC), (user_id, lesson_schedule_id)
+  - Add performance indexes: (user_id, status, payment_status), (user_id, current_period_start DESC), (user_id, lesson_schedule_id), (user_id, status, payment_status, current_period_start DESC, id DESC) / パフォーマンスインデックス追加: (user_id, status, payment_status), (user_id, current_period_start DESC), (user_id, lesson_schedule_id), (user_id, status, payment_status, current_period_start DESC, id DESC)
   - Optional: Add stripe_price_id column for audit trail / 任意: 監査用stripe_price_idカラムを追加
   - Purpose: Support advanced subscription management features / 目的: 高度なサブスクリプション管理機能をサポート
   - Requirements: 6.1 / 要件: 6.1

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -152,10 +152,21 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function getActiveSubscriptionForCategory(int $categoryId): ?UserSubscription
     {
+        $now = now();
+
         return $this->userSubscriptions()
             ->active()
             ->paid()
             ->forCategory($categoryId)
+            ->where(function ($q) use ($now) {
+                $q->whereNull('current_period_start')
+                    ->orWhere('current_period_start', '<=', $now);
+            })
+            ->where(function ($q) use ($now) {
+                $q->whereNull('current_period_end')
+                    ->orWhere('current_period_end', '>=', $now);
+            })
+            ->with('plan')
             ->orderByDesc('current_period_start')
             ->orderByDesc('id')
             ->first();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -146,4 +146,18 @@ class User extends Authenticatable implements MustVerifyEmail
         // Use app-specific subscription scopes
         return $this->userSubscriptions()->active()->paid();
     }
+
+    /**
+     * Get the latest active subscription that allows the given category.
+     */
+    public function getActiveSubscriptionForCategory(int $categoryId): ?UserSubscription
+    {
+        return $this->userSubscriptions()
+            ->active()
+            ->paid()
+            ->forCategory($categoryId)
+            ->orderByDesc('current_period_start')
+            ->orderByDesc('id')
+            ->first();
+    }
 }

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -101,7 +101,9 @@ class UserSubscription extends Model
      */
     public function hasRemainingLessons(): bool
     {
-        return $this->current_month_used_count < $this->plan->lesson_count;
+        $limit = $this->plan?->lesson_count ?? 0;
+
+        return $this->current_month_used_count < $limit;
     }
 
     /**
@@ -109,7 +111,9 @@ class UserSubscription extends Model
      */
     public function getRemainingLessonsAttribute(): int
     {
-        return max(0, $this->plan->lesson_count - $this->current_month_used_count);
+        $limit = $this->plan?->lesson_count ?? 0;
+
+        return max(0, $limit - $this->current_month_used_count);
     }
 
     /**
@@ -160,6 +164,9 @@ class UserSubscription extends Model
      */
     public function getFormattedPeriodAttribute(): string
     {
-        return $this->current_period_start->format('Y年m月d日').' ～ '.$this->current_period_end->format('Y年m月d日');
+        $start = $this->current_period_start?->format('Y年m月d日') ?? '-';
+        $end = $this->current_period_end?->format('Y年m月d日') ?? '-';
+
+        return "{$start} ～ {$end}";
     }
 }

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -56,7 +57,7 @@ class UserSubscription extends Model
     /**
      * Scope a query to only include active subscriptions.
      */
-    public function scopeActive($query)
+    public function scopeActive(Builder $query): Builder
     {
         return $query->where('status', 'active');
     }
@@ -64,9 +65,19 @@ class UserSubscription extends Model
     /**
      * Scope a query to only include paid subscriptions.
      */
-    public function scopePaid($query)
+    public function scopePaid(Builder $query): Builder
     {
         return $query->where('payment_status', 'paid');
+    }
+
+    /**
+     * Scope by lesson category allowed by the plan.
+     */
+    public function scopeForCategory(Builder $query, int $categoryId): Builder
+    {
+        return $query->whereHas('plan', function (Builder $planQuery) use ($categoryId): void {
+            $planQuery->whereJsonContains('allowed_category_ids', $categoryId);
+        });
     }
 
     /**
@@ -107,6 +118,41 @@ class UserSubscription extends Model
     public function allowsCategory(int $categoryId): bool
     {
         return $this->plan->allowsCategory($categoryId);
+    }
+
+    /**
+     * Alias for allowsCategory to match task specification.
+     */
+    public function hasCategory(int $categoryId): bool
+    {
+        return $this->allowsCategory($categoryId);
+    }
+
+    /**
+     * Determine if the user can book the given lesson under this subscription.
+     */
+    public function canBookLesson(Lesson $lesson): bool
+    {
+        if (! $this->isActive() || ! $this->isPaid()) {
+            return false;
+        }
+
+        // Period validity check
+        $now = now();
+        if ($this->current_period_start && $now->lt($this->current_period_start)) {
+            return false;
+        }
+        if ($this->current_period_end && $now->gt($this->current_period_end)) {
+            return false;
+        }
+
+        // Category permission
+        if (! $this->hasCategory((int) $lesson->category_id)) {
+            return false;
+        }
+
+        // Lesson count enforcement
+        return $this->hasRemainingLessons();
     }
 
     /**

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -121,7 +121,7 @@ class UserSubscription extends Model
      */
     public function allowsCategory(int $categoryId): bool
     {
-        return $this->plan->allowsCategory($categoryId);
+        return $this->plan?->allowsCategory($categoryId) ?? false;
     }
 
     /**

--- a/database/migrations/2025_09_17_142124_add_composite_index_to_user_subscriptions.php
+++ b/database/migrations/2025_09_17_142124_add_composite_index_to_user_subscriptions.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            // Composite index to speed up active subscription lookups
+            $table->index(['user_id', 'status', 'payment_status', 'current_period_start', 'id'], 'user_subs_active_lookup_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            $table->dropIndex('user_subs_active_lookup_idx');
+        });
+    }
+};


### PR DESCRIPTION
- UserSubscription::scopeForCategory() スコープを追加
- UserSubscription::hasCategory() メソッドを追加
- UserSubscription::canBookLesson() メソッドを追加（回数制限付き）
- User::getActiveSubscriptionForCategory() メソッドを追加
- 優先順位: current_period_start DESC, id DESC
- 回数制限を強制: 予約許可前に残り回数をチェック
- 二層サブスクリプション管理アーキテクチャの実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  * カテゴリ別の有効サブスクリプション取得に対応。該当カテゴリの最新有効プランを自動判定。
  * レッスン予約可否判定を追加（有効・支払い済・期間内・カテゴリ許可・残回数確認）。

* 改善
  * 残回数・期間表示の耐障害性を向上し、表示が欠落する場合はプレースホルダーを返すように修正。
  * 予約判定ロジックを統一して精度を向上。

* チョア
  * 予約関連検索を高速化するための複合インデックスを追加。
  * 内部タスクの進捗を更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->