### PR TITLE
feat: Task 29 - プラン切り替え機能を実装

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -284,7 +284,7 @@
   - Dependencies: Task 27 / 依存関係: タスク27
   - Estimated time: 30 minutes / 推定時間: 30分
 
-- [ ] 29. Implement plan switching functionality / プラン切り替え機能を実装
+- [x] 29. Implement plan switching functionality / プラン切り替え機能を実装
   - File: app/Services/SubscriptionService.php (new) / ファイル: app/Services/SubscriptionService.php (新規)
   - Add SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): void method / SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): voidメソッドを追加
   - Implement same-category-only switching rule with validation / 同じカテゴリー内のみ切り替え可能ルールとバリデーションを実装

--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -286,10 +286,11 @@
 
 - [x] 29. Implement plan switching functionality / プラン切り替え機能を実装
   - File: app/Services/SubscriptionService.php (new) / ファイル: app/Services/SubscriptionService.php (新規)
-  - Add SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): void method / SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): voidメソッドを追加
+  - Add SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): StripeCheckoutSession method / SubscriptionService::switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): StripeCheckoutSessionメソッドを追加
   - Implement same-category-only switching rule with validation / 同じカテゴリー内のみ切り替え可能ルールとバリデーションを実装
-  - Calculate remaining lessons: old_plan.lesson_count - current_month_used_count / 残り回数計算: old_plan.lesson_count - current_month_used_count
-  - Create Checkout Session with remaining lessons metadata / 残り回数メタデータ付きCheckout Session作成
+  - Calculate remaining lessons at webhook time to avoid race: new_remaining = old_plan.lesson_count - current_month_used_count (at completion) / レース回避のため Webhook 時点で再計算
+  - Create Checkout Session with hint metadata (remaining_calculated_at, ids) / 参考用メタデータ（remaining_calculated_at 等）を付与
+  - Use idempotency_key for session creation (format example: switch:{user_id}:{from_id}:{to_id}:{minute_ts}) / セッション作成に idempotency_key を付与
   - Handle Stripe subscription cancellation and creation via webhooks / Webhook経由でStripeサブスクリプションのキャンセルと作成を処理
   - New subscription: new_plan.lesson_count + remaining_lessons / 新サブスクリプション: new_plan.lesson_count + remaining_lessons
   - Purpose: Allow users to switch between plans within the same category with remaining lessons transfer / 目的: ユーザーが同じカテゴリー内でプランを切り替え可能にし、残り回数を引継ぎ

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+use Stripe\Checkout\Session as StripeCheckoutSession;
+use Stripe\StripeClient;
+
+class SubscriptionService
+{
+    public function __construct(private readonly StripeClient $stripe) {}
+
+    /**
+     * Initiate a plan switch by creating a Stripe Checkout Session.
+     * - Validates same-category rule
+     * - Calculates remaining lessons (old_plan.lesson_count - current_month_used_count)
+     * - Adds remaining lessons metadata so webhook can apply new_plan.lesson_count + remaining
+     */
+    public function switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): StripeCheckoutSession
+    {
+        // Validate same-category-only rule: intersection of allowed categories must be non-empty
+        $fromCategories = $from->allowed_category_ids ?? [];
+        $toCategories = $to->allowed_category_ids ?? [];
+        $shared = array_values(array_intersect($fromCategories, $toCategories));
+        if (empty($shared)) {
+            throw ValidationException::withMessages([
+                'plan' => '同じカテゴリー内のプランのみ切り替えできます。',
+            ]);
+        }
+
+        // Find the user's active paid subscription for the FROM plan
+        /** @var UserSubscription|null $current */
+        $current = $user->userSubscriptions()
+            ->where('plan_id', $from->getKey())
+            ->active()
+            ->paid()
+            ->orderByDesc('current_period_start')
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $current) {
+            throw ValidationException::withMessages([
+                'subscription' => '切替元の有効なサブスクリプションが見つかりません。',
+            ]);
+        }
+
+        // Calculate remaining lessons for transfer
+        $remaining = max(0, (int) $from->lesson_count - (int) $current->current_month_used_count);
+
+        // Ensure Stripe customer exists
+        $user->createOrGetStripeCustomer();
+
+        // Build URLs
+        $successUrl = route('subscription.success', ['session_id' => '{CHECKOUT_SESSION_ID}'], true);
+        $cancelUrl = route('subscription.cancel', [], true);
+
+        // Create Checkout Session for the TO plan with remaining lessons metadata
+        try {
+            $session = $this->stripe->checkout->sessions->create([
+                'mode' => 'subscription',
+                'customer' => $user->stripe_id,
+                'line_items' => [
+                    [
+                        'price' => $to->stripe_price_id,
+                        'quantity' => 1,
+                    ],
+                ],
+                'success_url' => $successUrl,
+                'cancel_url' => $cancelUrl,
+                'locale' => 'ja',
+                'client_reference_id' => (string) $user->getKey(),
+                'metadata' => [
+                    'switch_from_app_plan_id' => (string) $from->getKey(),
+                    'switch_to_app_plan_id' => (string) $to->getKey(),
+                    'remaining_lessons' => (string) $remaining,
+                    // Optional: assist webhook with category context
+                    'switch_shared_category_id' => (string) Arr::first($shared),
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            report($e);
+            throw ValidationException::withMessages([
+                'subscription' => 'プラン切替用の決済セッション作成に失敗しました。時間をおいて再度お試しください。',
+            ]);
+        }
+
+        return $session;
+    }
+}

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -19,12 +19,14 @@ class SubscriptionService
      * - Validates same-category rule
      * - Calculates remaining lessons (old_plan.lesson_count - current_month_used_count)
      * - Adds remaining lessons metadata so webhook can apply new_plan.lesson_count + remaining
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function switchPlan(User $user, SubscriptionPlan $from, SubscriptionPlan $to): StripeCheckoutSession
     {
         // Validate same-category-only rule: intersection of allowed categories must be non-empty
-        $fromCategories = $from->allowed_category_ids ?? [];
-        $toCategories = $to->allowed_category_ids ?? [];
+        $fromCategories = array_map('intval', Arr::wrap($from->allowed_category_ids));
+        $toCategories = array_map('intval', Arr::wrap($to->allowed_category_ids));
         $shared = array_values(array_intersect($fromCategories, $toCategories));
         if (empty($shared)) {
             throw ValidationException::withMessages([
@@ -48,18 +50,34 @@ class SubscriptionService
             ]);
         }
 
-        // Calculate remaining lessons for transfer
+        // Calculate remaining lessons (hint only). Final value is recalculated at webhook time.
         $remaining = max(0, (int) $from->lesson_count - (int) $current->current_month_used_count);
 
-        // Ensure Stripe customer exists
-        $user->createOrGetStripeCustomer();
+        // Guard: ensure target price exists
+        if (empty($to->stripe_price_id)) {
+            throw ValidationException::withMessages([
+                'plan' => '切替先プランの価格設定が不正です。',
+            ]);
+        }
 
         // Build URLs
         $successUrl = route('subscription.success', ['session_id' => '{CHECKOUT_SESSION_ID}'], true);
         $cancelUrl = route('subscription.cancel', [], true);
 
+        // Idempotency key (minute-granularity to mitigate double-submit)
+        $idempotencyKey = sprintf(
+            'switch:%d:%d:%d:%s',
+            $user->getKey(),
+            $from->getKey(),
+            $to->getKey(),
+            now()->startOfMinute()->timestamp
+        );
+
         // Create Checkout Session for the TO plan with remaining lessons metadata
         try {
+            // Ensure Stripe customer exists
+            $user->createOrGetStripeCustomer();
+
             $session = $this->stripe->checkout->sessions->create([
                 'mode' => 'subscription',
                 'customer' => $user->stripe_id,
@@ -76,11 +94,13 @@ class SubscriptionService
                 'metadata' => [
                     'switch_from_app_plan_id' => (string) $from->getKey(),
                     'switch_to_app_plan_id' => (string) $to->getKey(),
-                    'remaining_lessons' => (string) $remaining,
+                    // Hint only: webhook recalculates using latest usage at completion time
+                    'remaining_lessons_hint' => (string) $remaining,
+                    'remaining_calculated_at' => now()->toIso8601String(),
                     // Optional: assist webhook with category context
                     'switch_shared_category_id' => (string) Arr::first($shared),
                 ],
-            ]);
+            ], ['idempotency_key' => $idempotencyKey]);
         } catch (\Throwable $e) {
             report($e);
             throw ValidationException::withMessages([

--- a/database/migrations/2025_09_17_142124_add_composite_index_to_user_subscriptions.php
+++ b/database/migrations/2025_09_17_142124_add_composite_index_to_user_subscriptions.php
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::table('user_subscriptions', function (Blueprint $table) {
             // Composite index to speed up active subscription lookups
-            $table->index(['user_id', 'status', 'payment_status', 'current_period_start', 'id'], 'user_subs_active_lookup_idx');
+            // Include plan_id to support queries filtering by specific plan
+            $table->index(['user_id', 'plan_id', 'status', 'payment_status', 'current_period_start', 'id'], 'user_subs_active_lookup_idx');
         });
     }
 


### PR DESCRIPTION
- SubscriptionService::switchPlan() メソッドを追加
- 同じカテゴリー内のみ切り替え可能ルールとバリデーションを実装
- 残り回数計算: old_plan.lesson_count - current_month_used_count
- 残り回数メタデータ付きCheckout Session作成
- カテゴリー共有検証とエラーハンドリングを実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - サブスクリプションのプラン変更対応（同一カテゴリ内のみ）。
  - 未消化レッスン数はチェックアウト完了で確定する方式に変更（事前ヒントを付与）。
  - 決済チェックアウトに日本語の成功/キャンセル遷移と重複防止（冪等化）を導入。

- バグ修正・改善
  - 対象プラン未契約や不正な変更に対する日本語のわかりやすいエラーメッセージと堅牢な例外処理。

- 雑務
  - ユーザーサブスクリプション検索のためのインデックス改善（パフォーマンス向上）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->