### PR TITLE
feat: Task 30, 30.1, 30.2 - 回数管理機能とDBスキーマ強化を実装

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -298,7 +298,7 @@
   - Dependencies: Task 28 / 依存関係: タスク28
   - Estimated time: 45 minutes / 推定時間: 45分
 
-- [ ] 30. Implement lesson count management / 回数管理機能を実装
+- [x] 30. Implement lesson count management / 回数管理機能を実装
   - File: app/Models/UserSubscription.php (modify) / ファイル: app/Models/UserSubscription.php (修正)
   - Add UserSubscription::getTotalAvailableLessons(): int method / UserSubscription::getTotalAvailableLessons(): intメソッドを追加
   - Add UserSubscription::getRemainingLessons(): int method / UserSubscription::getRemainingLessons(): intメソッドを追加
@@ -312,7 +312,7 @@
   - Dependencies: Task 29 / 依存関係: タスク29
   - Estimated time: 25 minutes / 推定時間: 25分
 
-- [ ] 30.1. Add database schema enhancements for subscription management / サブスクリプション管理用データベーススキーマ強化を追加
+- [x] 30.1. Add database schema enhancements for subscription management / サブスクリプション管理用データベーススキーマ強化を追加
   - File: database/migrations/ (new migration files) / ファイル: database/migrations/ (新規マイグレーションファイル)
   - Add remaining_lessons column to user_subscriptions table / user_subscriptionsテーブルにremaining_lessonsカラムを追加
   - Create plan_switch_logs table for statistics / 統計用plan_switch_logsテーブルを作成
@@ -323,7 +323,7 @@
   - Dependencies: Task 30 / 依存関係: タスク30
   - Estimated time: 15 minutes / 推定時間: 15分
 
-- [ ] 30.2. Implement comprehensive error handling and user messaging / 包括的なエラーハンドリングとユーザーメッセージングを実装
+- [x] 30.2. Implement comprehensive error handling and user messaging / 包括的なエラーハンドリングとユーザーメッセージングを実装
   - File: app/Http/Controllers/SubscriptionController.php (modify), resources/lang/ (new files) / ファイル: app/Http/Controllers/SubscriptionController.php (修正), resources/lang/ (新規ファイル)
   - Define specific error messages for lesson count limit scenarios / 回数制限シナリオ用の具体的なエラーメッセージを定義
   - Define specific error messages for reservation blocking scenarios / 予約ブロックシナリオ用の具体的なエラーメッセージを定義
@@ -457,6 +457,18 @@
   - Requirements: 8.5 / 要件: 8.5
   - Dependencies: Task 38 / 依存関係: タスク38
   - Estimated time: 20 minutes / 推定時間: 20分
+
+- [ ] 40.1. Implement detailed error handling for reservation operations / 予約操作の詳細エラーハンドリングを実装
+  - File: app/Http/Controllers/ReservationController.php (modify), app/Http/Controllers/Admin/ReservationController.php (modify) / ファイル: app/Http/Controllers/ReservationController.php (修正), app/Http/Controllers/Admin/ReservationController.php (修正)
+  - Define specific error messages for reservation creation blocking scenarios / 予約作成ブロックシナリオ用の具体的なエラーメッセージを定義
+  - Define specific error messages for reservation cancellation scenarios / 予約キャンセルシナリオ用の具体的なエラーメッセージを定義
+  - Implement lesson count limit enforcement with user-friendly messages / ユーザーフレンドリーなメッセージで回数制限を強制
+  - Handle subscription status validation with clear feedback / 明確なフィードバックでサブスクリプション状態バリデーションを処理
+  - Add reservation deadline validation and messaging / 予約期限バリデーションとメッセージングを追加
+  - Purpose: Provide clear user feedback for reservation operations with count limits / 目的: 回数制限付きで予約操作に対する明確なユーザーフィードバックを提供
+  - Requirements: 8.3, 8.4, 8.5 / 要件: 8.3, 8.4, 8.5
+  - Dependencies: Task 40 / 依存関係: タスク40
+  - Estimated time: 25 minutes / 推定時間: 25分
 
 ### Notification System Implementation Tasks
 ### 通知システム実装タスク

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -86,7 +86,7 @@ class SubscriptionController extends Controller
                 ]);
             }
             throw ValidationException::withMessages([
-                'subscription' => trans('subscription.errors.reservation_blocked'),
+                'subscription' => trans('subscription.errors.checkout_failed'),
             ]);
         }
 
@@ -107,7 +107,7 @@ class SubscriptionController extends Controller
      */
     public function cancel(): RedirectResponse
     {
-        return redirect()->route('home')->with('status', 'サブスクリプション手続きがキャンセルされました。');
+        return redirect()->route('home')->with('status', trans('subscription.success.checkout_canceled'));
     }
 
     /**

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -86,7 +86,7 @@ class SubscriptionController extends Controller
                 ]);
             }
             throw ValidationException::withMessages([
-                'subscription' => '決済セッションの作成に失敗しました。時間をおいて再度お試しください。',
+                'subscription' => trans('subscription.errors.reservation_blocked'),
             ]);
         }
 

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -102,9 +102,7 @@ class UserSubscription extends Model
      */
     public function hasRemainingLessons(): bool
     {
-        $limit = $this->plan?->lesson_count ?? 0;
-
-        return $this->current_month_used_count < $limit;
+        return $this->getRemainingLessons() > 0;
     }
 
     /**
@@ -112,9 +110,13 @@ class UserSubscription extends Model
      */
     public function getRemainingLessonsAttribute(): int
     {
-        $limit = $this->plan?->lesson_count ?? 0;
+        // 永続値が存在すればそれを優先（負値は0に丸め）
+        if (array_key_exists('remaining_lessons', $this->attributes) && $this->attributes['remaining_lessons'] !== null) {
+            return max(0, (int) $this->attributes['remaining_lessons']);
+        }
+        $limit = (int) ($this->plan?->lesson_count ?? 0);
 
-        return max(0, $limit - $this->current_month_used_count);
+        return max(0, $limit - (int) $this->current_month_used_count);
     }
 
     /**
@@ -131,7 +133,7 @@ class UserSubscription extends Model
      */
     public function getRemainingLessons(): int
     {
-        // Prefer dynamic calculation to avoid stale values; persisted value will be handled by webhooks if adopted.
+        // Accessorに集約
         return $this->getRemainingLessonsAttribute();
     }
 

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -22,6 +22,7 @@ class UserSubscription extends Model
         'current_period_start',
         'current_period_end',
         'current_month_used_count',
+        'remaining_lessons',
     ];
 
     protected $casts = [
@@ -111,8 +112,9 @@ class UserSubscription extends Model
     public function getRemainingLessonsAttribute(): int
     {
         // 永続値が存在すればそれを優先（負値は0に丸め）
-        if (array_key_exists('remaining_lessons', $this->attributes) && $this->attributes['remaining_lessons'] !== null) {
-            return max(0, (int) $this->attributes['remaining_lessons']);
+        $raw = $this->getRawOriginal('remaining_lessons');
+        if ($raw !== null) {
+            return max(0, (int) $raw);
         }
         $limit = (int) ($this->plan?->lesson_count ?? 0);
 

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -28,6 +28,7 @@ class UserSubscription extends Model
         'current_period_start' => 'datetime',
         'current_period_end' => 'datetime',
         'current_month_used_count' => 'integer',
+        'remaining_lessons' => 'integer',
     ];
 
     /**
@@ -114,6 +115,24 @@ class UserSubscription extends Model
         $limit = $this->plan?->lesson_count ?? 0;
 
         return max(0, $limit - $this->current_month_used_count);
+    }
+
+    /**
+     * Total available lessons for the current period (plan-defined quota).
+     */
+    public function getTotalAvailableLessons(): int
+    {
+        return (int) ($this->plan?->lesson_count ?? 0);
+    }
+
+    /**
+     * Remaining lessons for the current period (method form).
+     * Mirrors the accessor while providing an explicit method per spec.
+     */
+    public function getRemainingLessons(): int
+    {
+        // Prefer dynamic calculation to avoid stale values; persisted value will be handled by webhooks if adopted.
+        return $this->getRemainingLessonsAttribute();
     }
 
     /**

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -30,7 +30,7 @@ class SubscriptionService
         $shared = array_values(array_intersect($fromCategories, $toCategories));
         if (empty($shared)) {
             throw ValidationException::withMessages([
-                'plan' => '同じカテゴリー内のプランのみ切り替えできます。',
+                'subscription' => trans('subscription.errors.plan_switch_invalid'),
             ]);
         }
 

--- a/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
+++ b/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
@@ -46,9 +46,9 @@ return new class extends Migration
         Schema::create('plan_switch_logs', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
-            $table->foreignId('from_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
-            $table->foreignId('to_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
-            $table->integer('remaining_lessons_hint')->default(0);
+            $table->foreignId('from_plan_id')->nullable()->constrained('subscription_plans')->nullOnDelete();
+            $table->foreignId('to_plan_id')->nullable()->constrained('subscription_plans')->nullOnDelete();
+            $table->unsignedInteger('remaining_lessons_hint')->default(0);
             $table->string('stripe_checkout_session_id', 255)->nullable();
             $table->unique('stripe_checkout_session_id', 'plan_switch_stripe_session_uidx');
             $table->timestamp('remaining_calculated_at')->nullable();

--- a/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
+++ b/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -12,9 +13,19 @@ return new class extends Migration
             if (! Schema::hasColumn('user_subscriptions', 'remaining_lessons')) {
                 $table->integer('remaining_lessons')->nullable()->after('current_month_used_count');
             }
-            // Performance indexes (some may already exist via previous migrations)
-            $table->index(['user_id', 'status', 'payment_status'], 'user_subs_status_idx');
-            $table->index(['user_id', 'current_period_start'], 'user_subs_period_start_idx');
+        });
+
+        // Indexes: guard against duplicates if they already exist from previous migrations
+        $hasStatusIdx = $this->indexExists('user_subscriptions', 'user_subs_status_idx');
+        $hasStartIdx = $this->indexExists('user_subscriptions', 'user_subs_period_start_idx');
+
+        Schema::table('user_subscriptions', function (Blueprint $table) use ($hasStatusIdx, $hasStartIdx): void {
+            if (! $hasStatusIdx) {
+                $table->index(['user_id', 'status', 'payment_status'], 'user_subs_status_idx');
+            }
+            if (! $hasStartIdx) {
+                $table->index(['user_id', 'current_period_start'], 'user_subs_period_start_idx');
+            }
         });
 
         Schema::create('plan_switch_logs', function (Blueprint $table): void {
@@ -24,6 +35,7 @@ return new class extends Migration
             $table->foreignId('to_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
             $table->integer('remaining_lessons_hint')->default(0);
             $table->string('stripe_checkout_session_id')->nullable();
+            $table->index('stripe_checkout_session_id', 'plan_switch_stripe_session_idx');
             $table->timestamp('remaining_calculated_at')->nullable();
             $table->json('meta')->nullable();
             $table->timestamps();
@@ -39,10 +51,55 @@ return new class extends Migration
             if (Schema::hasColumn('user_subscriptions', 'remaining_lessons')) {
                 $table->dropColumn('remaining_lessons');
             }
-            $table->dropIndex('user_subs_status_idx');
-            $table->dropIndex('user_subs_period_start_idx');
+            if ($this->indexExists('user_subscriptions', 'user_subs_status_idx')) {
+                $table->dropIndex('user_subs_status_idx');
+            }
+            if ($this->indexExists('user_subscriptions', 'user_subs_period_start_idx')) {
+                $table->dropIndex('user_subs_period_start_idx');
+            }
         });
 
         Schema::dropIfExists('plan_switch_logs');
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        $connection = Schema::getConnection();
+        $driver = $connection->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('".$connection->getTablePrefix().$table."')");
+            foreach ($rows as $row) {
+                // PRAGMA index_list returns 'name' for index name
+                if (isset($row->name) && $row->name === $index) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $database = $connection->getDatabaseName();
+            $result = DB::select(
+                'SELECT 1 FROM information_schema.statistics WHERE table_schema = ? AND table_name = ? AND index_name = ? LIMIT 1',
+                [$database, $connection->getTablePrefix().$table, $index]
+            );
+
+            return ! empty($result);
+        }
+
+        if ($driver === 'pgsql') {
+            $schema = 'public';
+            $result = DB::select(
+                'SELECT 1 FROM pg_indexes WHERE schemaname = ? AND tablename = ? AND indexname = ? LIMIT 1',
+                [$schema, $connection->getTablePrefix().$table, $index]
+            );
+
+            return ! empty($result);
+        }
+
+        // Fallback: attempt safe drop with try/catch by reporting non-existence as false
+        return false;
     }
 };

--- a/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
+++ b/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table): void {
+            if (! Schema::hasColumn('user_subscriptions', 'remaining_lessons')) {
+                $table->integer('remaining_lessons')->nullable()->after('current_month_used_count');
+            }
+            // Performance indexes (some may already exist via previous migrations)
+            $table->index(['user_id', 'status', 'payment_status'], 'user_subs_status_idx');
+            $table->index(['user_id', 'current_period_start'], 'user_subs_period_start_idx');
+        });
+
+        Schema::create('plan_switch_logs', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('from_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
+            $table->foreignId('to_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
+            $table->integer('remaining_lessons_hint')->default(0);
+            $table->string('stripe_checkout_session_id')->nullable();
+            $table->timestamp('remaining_calculated_at')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            // Suggested performance indexes
+            $table->index(['user_id', 'created_at'], 'plan_switch_user_created_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table): void {
+            if (Schema::hasColumn('user_subscriptions', 'remaining_lessons')) {
+                $table->dropColumn('remaining_lessons');
+            }
+            $table->dropIndex('user_subs_status_idx');
+            $table->dropIndex('user_subs_period_start_idx');
+        });
+
+        Schema::dropIfExists('plan_switch_logs');
+    }
+};

--- a/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
+++ b/database/migrations/2025_09_18_000001_add_remaining_lessons_and_logs.php
@@ -15,6 +15,21 @@ return new class extends Migration
             }
         });
 
+        // Optional: non-negative guard (best-effort by driver)
+        $conn = Schema::getConnection();
+        $tableName = $conn->getTablePrefix().'user_subscriptions';
+        try {
+            if ($conn->getDriverName() === 'pgsql') {
+                DB::statement("ALTER TABLE {$tableName} ADD CONSTRAINT user_subs_remaining_nonneg CHECK (remaining_lessons IS NULL OR remaining_lessons >= 0)");
+            } elseif ($conn->getDriverName() === 'mysql') {
+                DB::statement("ALTER TABLE {$tableName} ADD CONSTRAINT user_subs_remaining_nonneg CHECK (remaining_lessons IS NULL OR remaining_lessons >= 0)");
+            } elseif ($conn->getDriverName() === 'sqlite') {
+                // SQLite は CHECK をサポートするが、テーブル再作成が必要になる場合があるためスキップ
+            }
+        } catch (\Throwable $e) {
+            // 制約追加が非対応/既存等の環境では黙殺
+        }
+
         // Indexes: guard against duplicates if they already exist from previous migrations
         $hasStatusIdx = $this->indexExists('user_subscriptions', 'user_subs_status_idx');
         $hasStartIdx = $this->indexExists('user_subscriptions', 'user_subs_period_start_idx');
@@ -34,8 +49,8 @@ return new class extends Migration
             $table->foreignId('from_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
             $table->foreignId('to_plan_id')->constrained('subscription_plans')->cascadeOnDelete();
             $table->integer('remaining_lessons_hint')->default(0);
-            $table->string('stripe_checkout_session_id')->nullable();
-            $table->index('stripe_checkout_session_id', 'plan_switch_stripe_session_idx');
+            $table->string('stripe_checkout_session_id', 255)->nullable();
+            $table->unique('stripe_checkout_session_id', 'plan_switch_stripe_session_uidx');
             $table->timestamp('remaining_calculated_at')->nullable();
             $table->json('meta')->nullable();
             $table->timestamps();

--- a/resources/lang/ja/subscription.php
+++ b/resources/lang/ja/subscription.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'errors' => [
+        'count_limit_reached' => 'ご利用可能な回数が上限に達しました。次回の期間開始後にお試しください。',
+        'reservation_blocked' => '現在のサブスクリプション状態では予約できません。',
+        'payment_failed_grace' => 'お支払いに失敗しました。3日間の猶予期間中にお手続きをお願いします。',
+        'plan_switch_invalid' => 'プラン切り替えに失敗しました。条件を確認して再度お試しください。',
+    ],
+    'success' => [
+        'reservation_canceled_refund' => '期限前キャンセルのため回数を戻しました。',
+    ],
+];

--- a/resources/lang/ja/subscription.php
+++ b/resources/lang/ja/subscription.php
@@ -6,8 +6,10 @@ return [
         'reservation_blocked' => '現在のサブスクリプション状態では予約できません。',
         'payment_failed_grace' => 'お支払いに失敗しました。3日間の猶予期間中にお手続きをお願いします。',
         'plan_switch_invalid' => 'プラン切り替えに失敗しました。条件を確認して再度お試しください。',
+        'checkout_failed' => '決済セッションの作成に失敗しました。時間をおいて再度お試しください。',
     ],
     'success' => [
         'reservation_canceled_refund' => '期限前キャンセルのため回数を戻しました。',
+        'checkout_canceled' => 'サブスクリプション手続きがキャンセルされました。',
     ],
 ];

--- a/tests/Feature/SubscriptionCategoryManagementTest.php
+++ b/tests/Feature/SubscriptionCategoryManagementTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\LessonCategory;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function seedCategories(): array
+{
+    $root = LessonCategory::factory()->create(['parent_id' => null]);
+    $a = LessonCategory::factory()->create(['parent_id' => $root->id]);
+    $b = LessonCategory::factory()->create(['parent_id' => $root->id]);
+
+    return [$root, $a, $b];
+}
+
+it('scopeForCategory filters subscriptions by plan allowed_category_ids', function () {
+    [$root, $a, $b] = seedCategories();
+    $user = User::factory()->create();
+
+    $planA = SubscriptionPlan::create([
+        'name' => 'Plan A',
+        'price' => 1000,
+        'lesson_count' => 2,
+        'allowed_category_ids' => [$a->id],
+        'stripe_product_id' => 'prod_aaa',
+        'stripe_price_id' => 'price_aaa',
+        'is_active' => true,
+    ]);
+    $planB = SubscriptionPlan::create([
+        'name' => 'Plan B',
+        'price' => 1500,
+        'lesson_count' => 3,
+        'allowed_category_ids' => [$b->id],
+        'stripe_product_id' => 'prod_bbb',
+        'stripe_price_id' => 'price_bbb',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $planA->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 0,
+    ]);
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $planB->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 0,
+    ]);
+
+    $subsForA = $user->userSubscriptions()->forCategory($a->id)->get();
+    expect($subsForA)->toHaveCount(1)
+        ->and($subsForA->first()->plan_id)->toBe($planA->id);
+});
+
+it('User::getActiveSubscriptionForCategory returns latest active within period', function () {
+    [$root, $a] = seedCategories();
+    $user = User::factory()->create();
+
+    $plan = SubscriptionPlan::create([
+        'name' => 'Plan',
+        'price' => 1000,
+        'lesson_count' => 2,
+        'allowed_category_ids' => [$a->id],
+        'stripe_product_id' => 'prod_x',
+        'stripe_price_id' => 'price_x',
+        'is_active' => true,
+    ]);
+
+    // Out of period (future start)
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->addDay(),
+        'current_period_end' => now()->addDays(31),
+        'current_month_used_count' => 0,
+    ]);
+
+    // In period (latest)
+    $latest = UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 0,
+    ]);
+
+    $found = $user->getActiveSubscriptionForCategory($a->id);
+    expect($found?->id)->toBe($latest->id);
+});

--- a/tests/Feature/SubscriptionCategoryManagementTest.php
+++ b/tests/Feature/SubscriptionCategoryManagementTest.php
@@ -61,9 +61,8 @@ it('scopeForCategory filters subscriptions by plan allowed_category_ids', functi
         'current_month_used_count' => 0,
     ]);
 
-    $subsForA = $user->userSubscriptions()->forCategory($a->id)->get();
-    expect($subsForA)->toHaveCount(1)
-        ->and($subsForA->first()->plan_id)->toBe($planA->id);
+    $subForA = $user->userSubscriptions()->forCategory($a->id)->sole();
+    expect($subForA->plan_id)->toBe($planA->id);
 });
 
 it('User::getActiveSubscriptionForCategory returns latest active within period', function () {

--- a/tests/Feature/SubscriptionCountManagementTest.php
+++ b/tests/Feature/SubscriptionCountManagementTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\LessonCategory;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('computes remaining lessons via accessor and methods', function () {
+    $root = LessonCategory::factory()->create(['parent_id' => null]);
+    $category = LessonCategory::factory()->create(['parent_id' => $root->id]);
+    $user = User::factory()->create();
+
+    $plan = SubscriptionPlan::create([
+        'name' => 'Count Plan',
+        'price' => 2000,
+        'lesson_count' => 4,
+        'allowed_category_ids' => [$category->id],
+        'stripe_product_id' => 'prod_cnt',
+        'stripe_price_id' => 'price_cnt',
+        'is_active' => true,
+    ]);
+
+    $sub = UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 1,
+    ]);
+
+    expect($sub->getTotalAvailableLessons())->toBe(4)
+        ->and($sub->remaining_lessons)->toBe(3)
+        ->and($sub->getRemainingLessons())->toBe(3)
+        ->and($sub->hasRemainingLessons())->toBeTrue();
+});

--- a/tests/Feature/SubscriptionCountManagementTest.php
+++ b/tests/Feature/SubscriptionCountManagementTest.php
@@ -39,3 +39,30 @@ it('computes remaining lessons via accessor and methods', function () {
         ->and($sub->getRemainingLessons())->toBe(3)
         ->and($sub->hasRemainingLessons())->toBeTrue();
 });
+
+it('denies when remaining lessons reach zero', function () {
+    $root = LessonCategory::factory()->create(['parent_id' => null]);
+    $category = LessonCategory::factory()->create(['parent_id' => $root->id]);
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Count Plan',
+        'price' => 2000,
+        'lesson_count' => 4,
+        'allowed_category_ids' => [$category->id],
+        'stripe_product_id' => 'prod_cnt',
+        'stripe_price_id' => 'price_cnt',
+        'is_active' => true,
+    ]);
+    $sub = UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 4,
+    ]);
+    expect($sub->getRemainingLessons())->toBe(0)
+        ->and($sub->hasRemainingLessons())->toBeFalse();
+});

--- a/tests/Feature/SubscriptionPlanSwitchingTest.php
+++ b/tests/Feature/SubscriptionPlanSwitchingTest.php
@@ -47,6 +47,12 @@ it('rejects switching across different categories', function () {
 
     $service = app(SubscriptionService::class);
 
-    $this->expectException(\Illuminate\Validation\ValidationException::class);
-    $service->switchPlan($user, $from, $to);
+    try {
+        $service->switchPlan($user, $from, $to);
+        $this->fail('ValidationException expected');
+    } catch (\Illuminate\Validation\ValidationException $e) {
+        expect($e->errors())->toHaveKey('subscription');
+        expect($e->errors()['subscription'][0] ?? null)
+            ->toBe(__('subscription.errors.plan_switch_invalid'));
+    }
 });

--- a/tests/Feature/SubscriptionPlanSwitchingTest.php
+++ b/tests/Feature/SubscriptionPlanSwitchingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\LessonCategory;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use App\Services\SubscriptionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('rejects switching across different categories', function () {
+    $user = User::factory()->create();
+    $root = LessonCategory::factory()->create(['parent_id' => null]);
+    $a = LessonCategory::factory()->create(['parent_id' => $root->id]);
+    $b = LessonCategory::factory()->create(['parent_id' => $root->id]);
+
+    $from = SubscriptionPlan::create([
+        'name' => 'From',
+        'price' => 1000,
+        'lesson_count' => 2,
+        'allowed_category_ids' => [$a->id],
+        'stripe_product_id' => 'prod_from',
+        'stripe_price_id' => 'price_from',
+        'is_active' => true,
+    ]);
+    $to = SubscriptionPlan::create([
+        'name' => 'To',
+        'price' => 1500,
+        'lesson_count' => 3,
+        'allowed_category_ids' => [$b->id],
+        'stripe_product_id' => 'prod_to',
+        'stripe_price_id' => 'price_to',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $from->id,
+        'stripe_subscription_id' => 'sub_'.uniqid(),
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay(),
+        'current_period_end' => now()->addMonth(),
+        'current_month_used_count' => 0,
+    ]);
+
+    $service = app(SubscriptionService::class);
+
+    $this->expectException(\Illuminate\Validation\ValidationException::class);
+    $service->switchPlan($user, $from, $to);
+});


### PR DESCRIPTION
- UserSubscriptionに回数管理メソッド追加（getTotalAvailableLessons, getRemainingLessons）
- remaining_lessonsカラムとplan_switch_logsテーブルのマイグレーション追加
- パフォーマンスインデックス追加（user_subs_status_idx, user_subs_period_start_idx）
- 日本語翻訳ファイル追加（subscription.php）
- SubscriptionControllerのエラーメッセージを翻訳キーに変更
- 包括的なテスト追加（カテゴリ管理、プラン切替、回数管理）

Refs: #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - カテゴリ別の有効サブスクリプション取得とレッスン予約可否判定を追加。
  - 総受講数・残り受講数を取得できるAPIを追加し、残りレッスンは永続化値を優先する挙動に変更。
  - プラン切替時の残りレッスン引き継ぎやカウント制約検証を強化。
- チョア
  - DBに残り受講数カラムとプラン切替ログ用テーブル、関連インデックスを追加するマイグレーションを追加。
  - 表示メッセージを翻訳キー化し日本語ロケールを追加。
- テスト
  - カテゴリ判定、残り受講数計算、プラン切替制約の自動テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->