### PR TITLE
Feature/task 31 stripe webhook integration

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -338,7 +338,7 @@
 ### Webhook Processing Tasks
 ### Webhook処理タスク
 
-- [ ] 31. Create webhook event listeners / Webhookイベントリスナーを作成
+- [x] 31. Create webhook event listeners / Webhookイベントリスナーを作成
   - File: app/Listeners/ (new listener classes) / ファイル: app/Listeners/ (新規リスナークラス)
   - Handle checkout.session.completed: user_subscriptions creation with period sync and remaining lessons transfer / checkout.session.completed: user_subscriptions作成、period同期、残り回数引継ぎ
   - Handle customer.subscription.created/updated/deleted: status/payment_status/period sync / customer.subscription.created/updated/deleted: status/payment_status/period同期

--- a/app/Http/Controllers/Admin/SubscriptionPlanController.php
+++ b/app/Http/Controllers/Admin/SubscriptionPlanController.php
@@ -164,7 +164,7 @@ class SubscriptionPlanController extends Controller
         } catch (\Throwable $e) {
             report($e);
 
-            return response()->json(['success' => false], 422);
+            return response()->json(['success' => false, 'error' => 'stripe_price_lookup_failed'], 422);
         }
 
         if (! (($price->active ?? false)
@@ -172,7 +172,7 @@ class SubscriptionPlanController extends Controller
             && (strtolower($price->currency ?? '') === 'jpy')
             && (((bool) ($price->livemode ?? false)) === app()->environment('production'))
         )) {
-            return response()->json(['success' => false], 422);
+            return response()->json(['success' => false, 'error' => 'stripe_price_invalid'], 422);
         }
 
         return response()->json([
@@ -309,9 +309,7 @@ class SubscriptionPlanController extends Controller
                     $queue = $queue->merge($children->pluck('id'));
                 }
             }
-            if (! $hasAnyChild && in_array($id, $allIds, true)) {
-                $expanded->push($id);
-            }
+            // ここでの再 push は不要（BFS 中に葉を push 済み）
         }
 
         return $expanded->unique()->values()->all();

--- a/app/Http/Controllers/Admin/SubscriptionPlanController.php
+++ b/app/Http/Controllers/Admin/SubscriptionPlanController.php
@@ -8,9 +8,9 @@ use App\Http\Requests\UpdateSubscriptionPlanRequest;
 use App\Models\LessonCategory;
 use App\Models\SubscriptionPlan;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationException;
 use Stripe\StripeClient;
 
@@ -34,6 +34,7 @@ class SubscriptionPlanController extends Controller
     public function create(): View
     {
         $categories = LessonCategory::query()->orderBy('sort_order')->orderBy('id')->get();
+
         return view('admin.subscription_plans.create', compact('categories'));
     }
 
@@ -49,7 +50,7 @@ class SubscriptionPlanController extends Controller
         // Expand any selected parent categories into their child categories (server-side safety net)
         $data['allowed_category_ids'] = $this->expandCategoryIds($data['allowed_category_ids'] ?? []);
 
-        $plan = new SubscriptionPlan();
+        $plan = new SubscriptionPlan;
         $plan->fill([
             'name' => $data['name'],
             'price' => $data['price'],
@@ -71,7 +72,7 @@ class SubscriptionPlanController extends Controller
     public function show(SubscriptionPlan $subscriptionPlan): View
     {
         $allowedCategories = collect();
-        if (!empty($subscriptionPlan->allowed_category_ids)) {
+        if (! empty($subscriptionPlan->allowed_category_ids)) {
             $allowedCategories = LessonCategory::query()
                 ->whereIn('id', $subscriptionPlan->allowed_category_ids ?? [])
                 ->get(['id', 'name']);
@@ -89,6 +90,7 @@ class SubscriptionPlanController extends Controller
     public function edit(SubscriptionPlan $subscriptionPlan): View
     {
         $categories = LessonCategory::query()->orderBy('sort_order')->orderBy('id')->get();
+
         return view('admin.subscription_plans.edit', [
             'plan' => $subscriptionPlan,
             'categories' => $categories,
@@ -161,10 +163,11 @@ class SubscriptionPlanController extends Controller
             $price = $this->stripe()->prices->retrieve($validated['price_id'], []);
         } catch (\Throwable $e) {
             report($e);
+
             return response()->json(['success' => false], 422);
         }
 
-        if (!(($price->active ?? false)
+        if (! (($price->active ?? false)
             && (($price->type ?? '') === 'recurring')
             && (strtolower($price->currency ?? '') === 'jpy')
             && (((bool) ($price->livemode ?? false)) === app()->environment('production'))
@@ -199,7 +202,6 @@ class SubscriptionPlanController extends Controller
 
         $client = new StripeClient([
             'api_key' => $secret,
-            'max_network_retries' => 2,
         ]);
 
         return $client;
@@ -221,7 +223,7 @@ class SubscriptionPlanController extends Controller
             ]);
         }
 
-        if (!($price->active ?? false)) {
+        if (! ($price->active ?? false)) {
             throw ValidationException::withMessages([
                 'stripe_price_id' => 'Price が非アクティブです。',
             ]);
@@ -258,7 +260,7 @@ class SubscriptionPlanController extends Controller
         }
 
         // Product一致確認（productId が与えられている場合のみ）
-        if (!empty($productId)) {
+        if (! empty($productId)) {
             $productIdFromPrice = is_object($price->product) ? ($price->product->id ?? null) : ($price->product ?? null);
             if ($productIdFromPrice !== $productId) {
                 throw ValidationException::withMessages([
@@ -307,7 +309,7 @@ class SubscriptionPlanController extends Controller
                     $queue = $queue->merge($children->pluck('id'));
                 }
             }
-            if (!$hasAnyChild && in_array($id, $allIds, true)) {
+            if (! $hasAnyChild && in_array($id, $allIds, true)) {
                 $expanded->push($id);
             }
         }

--- a/app/Jobs/ProcessCheckoutSessionCompleted.php
+++ b/app/Jobs/ProcessCheckoutSessionCompleted.php
@@ -34,6 +34,9 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
         $metadata = (array) ($session['metadata'] ?? []);
 
         $stripeSubscriptionId = (string) ($session['subscription'] ?? '');
+        if (($session['mode'] ?? null) !== 'subscription') {
+            return;
+        }
         if ($stripeSubscriptionId === '') {
             return; // Not a subscription checkout
         }
@@ -43,6 +46,8 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
             : (is_numeric($session['client_reference_id'] ?? null) ? (int) $session['client_reference_id'] : 0);
         $planId = (int) ($metadata['app_plan_id'] ?? 0);
         if ($userId <= 0 || $planId <= 0) {
+            Log::info('checkout.session.completed skipped: missing ids', ['user_id' => $userId, 'plan_id' => $planId]);
+
             return; // Missing required identifiers
         }
 
@@ -89,22 +94,32 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
             ? max(0, (int) $plan->lesson_count + max(0, $remainingHint))
             : (int) $plan->lesson_count;
 
-        // Upsert by Stripe subscription id (unique)
-        UserSubscription::query()->updateOrCreate(
-            [
-                'stripe_subscription_id' => $stripeSubscriptionId,
-            ],
-            [
-                'user_id' => $user->getKey(),
-                'plan_id' => $plan->getKey(),
-                'status' => $status,
-                // Session が 'paid' のときのみ即時反映。そうでなければ invoice.* で最終確定
-                'payment_status' => (($session['payment_status'] ?? null) === 'paid') ? 'paid' : ($this->payload['_noop_payment_status'] ?? null),
-                'current_period_start' => $periodStart,
-                'current_period_end' => $periodEnd,
-                'current_month_used_count' => 0,
-                'remaining_lessons' => $initialRemaining,
-            ]
-        );
+        // 冪等にする: 既存が同一期間ならカウンタ保持、期間更新時のみリセット
+        /** @var UserSubscription $us */
+        $us = UserSubscription::query()->firstOrNew([
+            'stripe_subscription_id' => $stripeSubscriptionId,
+        ]);
+        $us->user_id = $user->getKey();
+        $us->plan_id = $plan->getKey();
+        $us->status = $status;
+        $us->payment_status = (($session['payment_status'] ?? null) === 'paid')
+            ? 'paid'
+            : ($this->payload['_noop_payment_status'] ?? $us->payment_status);
+
+        $samePeriod = $us->exists
+            && ($us->current_period_start instanceof \Carbon\CarbonInterface)
+            && ($us->current_period_end instanceof \Carbon\CarbonInterface)
+            && $us->current_period_start->equalTo($periodStart)
+            && $us->current_period_end->equalTo($periodEnd);
+
+        $us->current_period_start = $periodStart;
+        $us->current_period_end = $periodEnd;
+
+        if (! $samePeriod) {
+            $us->current_month_used_count = 0;
+            $us->remaining_lessons = $initialRemaining;
+        }
+
+        $us->save();
     }
 }

--- a/app/Jobs/ProcessCheckoutSessionCompleted.php
+++ b/app/Jobs/ProcessCheckoutSessionCompleted.php
@@ -38,7 +38,9 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
             return; // Not a subscription checkout
         }
 
-        $userId = (int) ($metadata['app_user_id'] ?? ($session['client_reference_id'] ?? 0));
+        $userId = isset($metadata['app_user_id'])
+            ? (int) $metadata['app_user_id']
+            : (is_numeric($session['client_reference_id'] ?? null) ? (int) $session['client_reference_id'] : 0);
         $planId = (int) ($metadata['app_plan_id'] ?? 0);
         if ($userId <= 0 || $planId <= 0) {
             return; // Missing required identifiers
@@ -53,8 +55,8 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
         }
 
         // Fetch subscription from Stripe for accurate period bounds when possible
-        $periodStart = now();
-        $periodEnd = now()->addMonth();
+        $periodStart = CarbonImmutable::now();
+        $periodEnd = CarbonImmutable::now()->addMonth();
         $status = 'active';
 
         try {
@@ -67,10 +69,10 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
                 $startTs = (int) ($sub->current_period_start ?? 0);
                 $endTs = (int) ($sub->current_period_end ?? 0);
                 if ($startTs > 0) {
-                    $periodStart = CarbonImmutable::createFromTimestamp($startTs);
+                    $periodStart = CarbonImmutable::createFromTimestampUTC($startTs);
                 }
                 if ($endTs > 0) {
-                    $periodEnd = CarbonImmutable::createFromTimestamp($endTs);
+                    $periodEnd = CarbonImmutable::createFromTimestampUTC($endTs);
                 }
             }
         } catch (\Throwable $e) {
@@ -96,7 +98,8 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
                 'user_id' => $user->getKey(),
                 'plan_id' => $plan->getKey(),
                 'status' => $status,
-                'payment_status' => 'paid',
+                // Session が 'paid' のときのみ即時反映。そうでなければ invoice.* で最終確定
+                'payment_status' => (($session['payment_status'] ?? null) === 'paid') ? 'paid' : ($this->payload['_noop_payment_status'] ?? null),
                 'current_period_start' => $periodStart,
                 'current_period_end' => $periodEnd,
                 'current_month_used_count' => 0,

--- a/app/Jobs/ProcessCheckoutSessionCompleted.php
+++ b/app/Jobs/ProcessCheckoutSessionCompleted.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessCheckoutSessionCompleted implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array<string, mixed> */
+    public array $payload;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        // Stub: implement creation of user_subscriptions and period sync, remaining lessons transfer
+    }
+}

--- a/app/Jobs/ProcessCheckoutSessionCompleted.php
+++ b/app/Jobs/ProcessCheckoutSessionCompleted.php
@@ -2,11 +2,18 @@
 
 namespace App\Jobs;
 
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Carbon\CarbonImmutable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Stripe\StripeClient;
 
 class ProcessCheckoutSessionCompleted implements ShouldQueue
 {
@@ -23,6 +30,78 @@ class ProcessCheckoutSessionCompleted implements ShouldQueue
 
     public function handle(): void
     {
-        // Stub: implement creation of user_subscriptions and period sync, remaining lessons transfer
+        $session = (array) Arr::get($this->payload, 'data.object', []);
+        $metadata = (array) ($session['metadata'] ?? []);
+
+        $stripeSubscriptionId = (string) ($session['subscription'] ?? '');
+        if ($stripeSubscriptionId === '') {
+            return; // Not a subscription checkout
+        }
+
+        $userId = (int) ($metadata['app_user_id'] ?? ($session['client_reference_id'] ?? 0));
+        $planId = (int) ($metadata['app_plan_id'] ?? 0);
+        if ($userId <= 0 || $planId <= 0) {
+            return; // Missing required identifiers
+        }
+
+        /** @var User|null $user */
+        $user = User::query()->find($userId);
+        /** @var SubscriptionPlan|null $plan */
+        $plan = SubscriptionPlan::query()->find($planId);
+        if (! $user || ! $plan) {
+            return;
+        }
+
+        // Fetch subscription from Stripe for accurate period bounds when possible
+        $periodStart = now();
+        $periodEnd = now()->addMonth();
+        $status = 'active';
+
+        try {
+            $secret = (string) config('services.stripe.secret');
+            if ($secret !== '') {
+                $client = new StripeClient(['api_key' => $secret]);
+                $sub = $client->subscriptions->retrieve($stripeSubscriptionId, []);
+                $status = (string) ($sub->status ?? $status);
+
+                $startTs = (int) ($sub->current_period_start ?? 0);
+                $endTs = (int) ($sub->current_period_end ?? 0);
+                if ($startTs > 0) {
+                    $periodStart = CarbonImmutable::createFromTimestamp($startTs);
+                }
+                if ($endTs > 0) {
+                    $periodEnd = CarbonImmutable::createFromTimestamp($endTs);
+                }
+            }
+        } catch (\Throwable $e) {
+            Log::warning('Stripe subscription fetch failed; using fallback period', [
+                'subscription' => $stripeSubscriptionId,
+                'message' => $e->getMessage(),
+            ]);
+        }
+
+        // Compute initial remaining lessons
+        $remainingHint = (int) ($metadata['remaining_lessons_hint'] ?? 0);
+        $isSwitch = isset($metadata['switch_to_app_plan_id']) || isset($metadata['switch_from_app_plan_id']);
+        $initialRemaining = $isSwitch
+            ? max(0, (int) $plan->lesson_count + max(0, $remainingHint))
+            : (int) $plan->lesson_count;
+
+        // Upsert by Stripe subscription id (unique)
+        UserSubscription::query()->updateOrCreate(
+            [
+                'stripe_subscription_id' => $stripeSubscriptionId,
+            ],
+            [
+                'user_id' => $user->getKey(),
+                'plan_id' => $plan->getKey(),
+                'status' => $status,
+                'payment_status' => 'paid',
+                'current_period_start' => $periodStart,
+                'current_period_end' => $periodEnd,
+                'current_month_used_count' => 0,
+                'remaining_lessons' => $initialRemaining,
+            ]
+        );
     }
 }

--- a/app/Jobs/ProcessCustomerSubscriptionDeleted.php
+++ b/app/Jobs/ProcessCustomerSubscriptionDeleted.php
@@ -2,11 +2,13 @@
 
 namespace App\Jobs;
 
+use App\Models\UserSubscription;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 
 class ProcessCustomerSubscriptionDeleted implements ShouldQueue
 {
@@ -23,6 +25,17 @@ class ProcessCustomerSubscriptionDeleted implements ShouldQueue
 
     public function handle(): void
     {
-        // Stub: implement deletion sync / set status canceled
+        $object = (array) Arr::get($this->payload, 'data.object', []);
+        $stripeId = (string) ($object['id'] ?? '');
+        if ($stripeId === '') {
+            return;
+        }
+
+        UserSubscription::query()
+            ->where('stripe_subscription_id', $stripeId)
+            ->update([
+                'status' => 'canceled',
+                'payment_status' => 'failed',
+            ]);
     }
 }

--- a/app/Jobs/ProcessCustomerSubscriptionDeleted.php
+++ b/app/Jobs/ProcessCustomerSubscriptionDeleted.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessCustomerSubscriptionDeleted implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array<string, mixed> */
+    public array $payload;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        // Stub: implement deletion sync / set status canceled
+    }
+}

--- a/app/Jobs/ProcessCustomerSubscriptionUpdated.php
+++ b/app/Jobs/ProcessCustomerSubscriptionUpdated.php
@@ -40,10 +40,10 @@ class ProcessCustomerSubscriptionUpdated implements ShouldQueue
             'status' => $status,
         ];
         if ($startTs > 0) {
-            $update['current_period_start'] = CarbonImmutable::createFromTimestamp($startTs);
+            $update['current_period_start'] = CarbonImmutable::createFromTimestampUTC($startTs);
         }
         if ($endTs > 0) {
-            $update['current_period_end'] = CarbonImmutable::createFromTimestamp($endTs);
+            $update['current_period_end'] = CarbonImmutable::createFromTimestampUTC($endTs);
         }
 
         // If invoice was paid, Cashier also emits invoice.payment_succeeded,

--- a/app/Jobs/ProcessCustomerSubscriptionUpdated.php
+++ b/app/Jobs/ProcessCustomerSubscriptionUpdated.php
@@ -2,11 +2,14 @@
 
 namespace App\Jobs;
 
+use App\Models\UserSubscription;
+use Carbon\CarbonImmutable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 
 class ProcessCustomerSubscriptionUpdated implements ShouldQueue
 {
@@ -23,6 +26,30 @@ class ProcessCustomerSubscriptionUpdated implements ShouldQueue
 
     public function handle(): void
     {
-        // Stub: implement status/payment_status/period sync
+        $object = (array) Arr::get($this->payload, 'data.object', []);
+        $stripeId = (string) ($object['id'] ?? '');
+        if ($stripeId === '') {
+            return;
+        }
+
+        $status = (string) ($object['status'] ?? 'active');
+        $startTs = (int) ($object['current_period_start'] ?? 0);
+        $endTs = (int) ($object['current_period_end'] ?? 0);
+
+        $update = [
+            'status' => $status,
+        ];
+        if ($startTs > 0) {
+            $update['current_period_start'] = CarbonImmutable::createFromTimestamp($startTs);
+        }
+        if ($endTs > 0) {
+            $update['current_period_end'] = CarbonImmutable::createFromTimestamp($endTs);
+        }
+
+        // If invoice was paid, Cashier also emits invoice.payment_succeeded,
+        // but here we only reflect status/period; payment_status handled elsewhere.
+        UserSubscription::query()
+            ->where('stripe_subscription_id', $stripeId)
+            ->update($update);
     }
 }

--- a/app/Jobs/ProcessCustomerSubscriptionUpdated.php
+++ b/app/Jobs/ProcessCustomerSubscriptionUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessCustomerSubscriptionUpdated implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array<string, mixed> */
+    public array $payload;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        // Stub: implement status/payment_status/period sync
+    }
+}

--- a/app/Jobs/ProcessInvoicePaid.php
+++ b/app/Jobs/ProcessInvoicePaid.php
@@ -2,11 +2,14 @@
 
 namespace App\Jobs;
 
+use App\Models\UserSubscription;
+use Carbon\CarbonImmutable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 
 class ProcessInvoicePaid implements ShouldQueue
 {
@@ -23,6 +26,29 @@ class ProcessInvoicePaid implements ShouldQueue
 
     public function handle(): void
     {
-        // Stub: implement period sync and current_month_used_count reset
+        $invoice = (array) Arr::get($this->payload, 'data.object', []);
+        $lines = (array) ($invoice['lines']['data'] ?? []);
+        $subscriptionId = (string) ($invoice['subscription'] ?? '');
+        if ($subscriptionId === '') {
+            return;
+        }
+
+        $periodStart = (int) ($invoice['lines']['data'][0]['period']['start'] ?? 0);
+        $periodEnd = (int) ($invoice['lines']['data'][0]['period']['end'] ?? 0);
+
+        $update = [
+            'payment_status' => 'paid',
+            'current_month_used_count' => 0,
+        ];
+        if ($periodStart > 0) {
+            $update['current_period_start'] = CarbonImmutable::createFromTimestamp($periodStart);
+        }
+        if ($periodEnd > 0) {
+            $update['current_period_end'] = CarbonImmutable::createFromTimestamp($periodEnd);
+        }
+
+        UserSubscription::query()
+            ->where('stripe_subscription_id', $subscriptionId)
+            ->update($update);
     }
 }

--- a/app/Jobs/ProcessInvoicePaid.php
+++ b/app/Jobs/ProcessInvoicePaid.php
@@ -27,24 +27,23 @@ class ProcessInvoicePaid implements ShouldQueue
     public function handle(): void
     {
         $invoice = (array) Arr::get($this->payload, 'data.object', []);
-        $lines = (array) ($invoice['lines']['data'] ?? []);
         $subscriptionId = (string) ($invoice['subscription'] ?? '');
         if ($subscriptionId === '') {
             return;
         }
 
-        $periodStart = (int) ($invoice['lines']['data'][0]['period']['start'] ?? 0);
-        $periodEnd = (int) ($invoice['lines']['data'][0]['period']['end'] ?? 0);
+        $periodStart = (int) Arr::get($invoice, 'lines.data.0.period.start', 0);
+        $periodEnd = (int) Arr::get($invoice, 'lines.data.0.period.end', 0);
 
         $update = [
             'payment_status' => 'paid',
             'current_month_used_count' => 0,
         ];
         if ($periodStart > 0) {
-            $update['current_period_start'] = CarbonImmutable::createFromTimestamp($periodStart);
+            $update['current_period_start'] = CarbonImmutable::createFromTimestampUTC($periodStart);
         }
         if ($periodEnd > 0) {
-            $update['current_period_end'] = CarbonImmutable::createFromTimestamp($periodEnd);
+            $update['current_period_end'] = CarbonImmutable::createFromTimestampUTC($periodEnd);
         }
 
         UserSubscription::query()

--- a/app/Jobs/ProcessInvoicePaid.php
+++ b/app/Jobs/ProcessInvoicePaid.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessInvoicePaid implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array<string, mixed> */
+    public array $payload;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        // Stub: implement period sync and current_month_used_count reset
+    }
+}

--- a/app/Jobs/ProcessInvoicePaymentFailed.php
+++ b/app/Jobs/ProcessInvoicePaymentFailed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessInvoicePaymentFailed implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array<string, mixed> */
+    public array $payload;
+
+    /** @param array<string, mixed> $payload */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        // Stub: set payment_status failed and enforce reservation blocking
+    }
+}

--- a/app/Jobs/ProcessInvoicePaymentFailed.php
+++ b/app/Jobs/ProcessInvoicePaymentFailed.php
@@ -2,11 +2,13 @@
 
 namespace App\Jobs;
 
+use App\Models\UserSubscription;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
 
 class ProcessInvoicePaymentFailed implements ShouldQueue
 {
@@ -23,6 +25,16 @@ class ProcessInvoicePaymentFailed implements ShouldQueue
 
     public function handle(): void
     {
-        // Stub: set payment_status failed and enforce reservation blocking
+        $invoice = (array) Arr::get($this->payload, 'data.object', []);
+        $subscriptionId = (string) ($invoice['subscription'] ?? '');
+        if ($subscriptionId === '') {
+            return;
+        }
+
+        UserSubscription::query()
+            ->where('stripe_subscription_id', $subscriptionId)
+            ->update([
+                'payment_status' => 'failed',
+            ]);
     }
 }

--- a/app/Listeners/StripeWebhookListener.php
+++ b/app/Listeners/StripeWebhookListener.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Jobs\ProcessCheckoutSessionCompleted;
+use App\Jobs\ProcessCustomerSubscriptionDeleted;
+use App\Jobs\ProcessCustomerSubscriptionUpdated;
+use App\Jobs\ProcessInvoicePaid;
+use App\Jobs\ProcessInvoicePaymentFailed;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Laravel\Cashier\Events\WebhookReceived;
+
+class StripeWebhookListener implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Allowed Stripe event types.
+     *
+     * @var array<int, string>
+     */
+    private array $allowedEventTypes = [
+        'checkout.session.completed',
+        'customer.subscription.created',
+        'customer.subscription.updated',
+        'customer.subscription.deleted',
+        'invoice.payment_succeeded',
+        'invoice.payment_failed',
+    ];
+
+    /**
+     * Handle the incoming webhook from Cashier.
+     */
+    public function handle(WebhookReceived $event): void
+    {
+        $payload = $event->payload;
+        $type = (string) ($payload['type'] ?? '');
+
+        if ($type === '' || ! in_array($type, $this->allowedEventTypes, true)) {
+            return; // Not allowed or malformed
+        }
+
+        // Basic idempotency using cache (7 days retention)
+        $eventId = (string) ($payload['id'] ?? '');
+        if ($eventId !== '') {
+            $cacheKey = 'stripe_webhook:processed:'.$eventId;
+            if (! Cache::add($cacheKey, true, now()->addDays(7))) {
+                // Duplicate event, already processed
+                return;
+            }
+        }
+
+        try {
+            switch ($type) {
+                case 'checkout.session.completed':
+                    ProcessCheckoutSessionCompleted::dispatch($payload);
+                    break;
+
+                case 'customer.subscription.created':
+                case 'customer.subscription.updated':
+                    ProcessCustomerSubscriptionUpdated::dispatch($payload);
+                    break;
+
+                case 'customer.subscription.deleted':
+                    ProcessCustomerSubscriptionDeleted::dispatch($payload);
+                    break;
+
+                case 'invoice.payment_succeeded':
+                    ProcessInvoicePaid::dispatch($payload);
+                    break;
+
+                case 'invoice.payment_failed':
+                    ProcessInvoicePaymentFailed::dispatch($payload);
+                    break;
+            }
+        } catch (\Throwable $e) {
+            Log::error('Stripe webhook listener error', [
+                'type' => $type,
+                'event_id' => $eventId,
+                'message' => $e->getMessage(),
+            ]);
+
+            // On failure, allow Stripe to retry by removing idempotency key for this event
+            if (! empty($eventId)) {
+                Cache::forget('stripe_webhook:processed:'.$eventId);
+            }
+        }
+    }
+}

--- a/app/Listeners/StripeWebhookListener.php
+++ b/app/Listeners/StripeWebhookListener.php
@@ -22,7 +22,7 @@ class StripeWebhookListener implements ShouldQueue
      *
      * @var array<int, string>
      */
-    private array $allowedEventTypes = [
+    private const ALLOWED_EVENT_TYPES = [
         'checkout.session.completed',
         'customer.subscription.created',
         'customer.subscription.updated',
@@ -39,7 +39,7 @@ class StripeWebhookListener implements ShouldQueue
         $payload = $event->payload;
         $type = (string) ($payload['type'] ?? '');
 
-        if ($type === '' || ! in_array($type, $this->allowedEventTypes, true)) {
+        if ($type === '' || ! in_array($type, self::ALLOWED_EVENT_TYPES, true)) {
             return; // Not allowed or malformed
         }
 
@@ -56,24 +56,24 @@ class StripeWebhookListener implements ShouldQueue
         try {
             switch ($type) {
                 case 'checkout.session.completed':
-                    ProcessCheckoutSessionCompleted::dispatch($payload);
+                    ProcessCheckoutSessionCompleted::dispatch($payload)->onQueue('stripe-webhooks');
                     break;
 
                 case 'customer.subscription.created':
                 case 'customer.subscription.updated':
-                    ProcessCustomerSubscriptionUpdated::dispatch($payload);
+                    ProcessCustomerSubscriptionUpdated::dispatch($payload)->onQueue('stripe-webhooks');
                     break;
 
                 case 'customer.subscription.deleted':
-                    ProcessCustomerSubscriptionDeleted::dispatch($payload);
+                    ProcessCustomerSubscriptionDeleted::dispatch($payload)->onQueue('stripe-webhooks');
                     break;
 
                 case 'invoice.payment_succeeded':
-                    ProcessInvoicePaid::dispatch($payload);
+                    ProcessInvoicePaid::dispatch($payload)->onQueue('stripe-webhooks');
                     break;
 
                 case 'invoice.payment_failed':
-                    ProcessInvoicePaymentFailed::dispatch($payload);
+                    ProcessInvoicePaymentFailed::dispatch($payload)->onQueue('stripe-webhooks');
                     break;
             }
         } catch (\Throwable $e) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,13 @@
 
 namespace App\Providers;
 
+use App\Listeners\StripeWebhookListener;
 use App\Models\User;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Cashier\Events\WebhookReceived;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -33,5 +36,8 @@ class AppServiceProvider extends ServiceProvider
         Gate::define('access-admin', fn (User $user): bool => $user->hasRole(User::ROLE_ADMIN));
         Gate::define('access-instructor', fn (User $user): bool => $user->hasRole(User::ROLE_INSTRUCTOR) || $user->hasRole(User::ROLE_ADMIN));
         Gate::define('manage-subscription-plans', fn (User $user): bool => $user->hasRole(User::ROLE_ADMIN));
+
+        // Register Stripe webhook listener via Cashier events
+        Event::listen(WebhookReceived::class, StripeWebhookListener::class);
     }
 }

--- a/tests/Feature/StripeJobsTest.php
+++ b/tests/Feature/StripeJobsTest.php
@@ -1,0 +1,272 @@
+<?php
+
+use App\Jobs\ProcessCheckoutSessionCompleted;
+use App\Jobs\ProcessCustomerSubscriptionDeleted;
+use App\Jobs\ProcessCustomerSubscriptionUpdated;
+use App\Jobs\ProcessInvoicePaid;
+use App\Jobs\ProcessInvoicePaymentFailed;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+it('creates or updates user subscription on checkout.session.completed (new subscription)', function (): void {
+    Carbon::setTestNow(Carbon::parse('2025-01-01 00:00:00'));
+
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Basic',
+        'price' => 1200,
+        'lesson_count' => 3,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_basic',
+        'stripe_price_id' => 'price_basic',
+        'is_active' => true,
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'subscription' => 'sub_cs_new',
+                'client_reference_id' => (string) $user->id,
+                'metadata' => [
+                    'app_user_id' => (string) $user->id,
+                    'app_plan_id' => (string) $plan->id,
+                ],
+            ],
+        ],
+    ];
+
+    (new ProcessCheckoutSessionCompleted($payload))->handle();
+
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_cs_new',
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_month_used_count' => 0,
+        'remaining_lessons' => 3,
+    ]);
+});
+
+it('transfers remaining lessons hint on plan switch at checkout.session.completed', function (): void {
+    Carbon::setTestNow(Carbon::parse('2025-02-01 00:00:00'));
+
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Plus',
+        'price' => 2200,
+        'lesson_count' => 4,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_plus',
+        'stripe_price_id' => 'price_plus',
+        'is_active' => true,
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'subscription' => 'sub_cs_switch',
+                'client_reference_id' => (string) $user->id,
+                'metadata' => [
+                    'app_user_id' => (string) $user->id,
+                    'app_plan_id' => (string) $plan->id,
+                    'switch_from_app_plan_id' => '1',
+                    'switch_to_app_plan_id' => (string) $plan->id,
+                    'remaining_lessons_hint' => '2',
+                ],
+            ],
+        ],
+    ];
+
+    (new ProcessCheckoutSessionCompleted($payload))->handle();
+
+    // remaining_lessons = new_plan.lesson_count + hint = 4 + 2 = 6
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_cs_switch',
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'remaining_lessons' => 6,
+    ]);
+});
+
+it('updates status and period on customer.subscription.updated', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Pro',
+        'price' => 3500,
+        'lesson_count' => 6,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_pro',
+        'stripe_price_id' => 'price_pro',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_upd',
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_month_used_count' => 0,
+        'current_period_start' => Carbon::parse('2025-03-01 00:00:00'),
+        'current_period_end' => Carbon::parse('2025-03-31 23:59:59'),
+    ]);
+
+    $start = Carbon::parse('2025-04-01 00:00:00')->timestamp;
+    $end = Carbon::parse('2025-04-30 23:59:59')->timestamp;
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'sub_upd',
+                'status' => 'past_due',
+                'current_period_start' => $start,
+                'current_period_end' => $end,
+            ],
+        ],
+    ];
+
+    (new ProcessCustomerSubscriptionUpdated($payload))->handle();
+
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_upd',
+        'status' => 'past_due',
+    ]);
+});
+
+it('sets canceled and failed on customer.subscription.deleted', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Lite',
+        'price' => 900,
+        'lesson_count' => 2,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_lite',
+        'stripe_price_id' => 'price_lite',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_del',
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_month_used_count' => 0,
+        'current_period_start' => Carbon::parse('2025-01-01 00:00:00'),
+        'current_period_end' => Carbon::parse('2025-01-31 23:59:59'),
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'sub_del',
+            ],
+        ],
+    ];
+
+    (new ProcessCustomerSubscriptionDeleted($payload))->handle();
+
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_del',
+        'status' => 'canceled',
+        'payment_status' => 'failed',
+    ]);
+});
+
+it('resets usage and marks paid on invoice.payment_succeeded', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Gold',
+        'price' => 5000,
+        'lesson_count' => 8,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_gold',
+        'stripe_price_id' => 'price_gold',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_paid',
+        'status' => 'active',
+        'payment_status' => 'failed',
+        'current_month_used_count' => 3,
+        'current_period_start' => Carbon::parse('2025-03-01 00:00:00'),
+        'current_period_end' => Carbon::parse('2025-03-31 23:59:59'),
+    ]);
+
+    $start = Carbon::parse('2025-04-01 00:00:00')->timestamp;
+    $end = Carbon::parse('2025-04-30 23:59:59')->timestamp;
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'subscription' => 'sub_paid',
+                'lines' => [
+                    'data' => [
+                        [
+                            'period' => [
+                                'start' => $start,
+                                'end' => $end,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    (new ProcessInvoicePaid($payload))->handle();
+
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_paid',
+        'payment_status' => 'paid',
+        'current_month_used_count' => 0,
+    ]);
+});
+
+it('marks payment failed on invoice.payment_failed', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::create([
+        'name' => 'Silver',
+        'price' => 3000,
+        'lesson_count' => 5,
+        'allowed_category_ids' => [],
+        'stripe_product_id' => 'prod_silver',
+        'stripe_price_id' => 'price_silver',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_fail',
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_month_used_count' => 1,
+        'current_period_start' => Carbon::parse('2025-05-01 00:00:00'),
+        'current_period_end' => Carbon::parse('2025-05-31 23:59:59'),
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'subscription' => 'sub_fail',
+            ],
+        ],
+    ];
+
+    (new ProcessInvoicePaymentFailed($payload))->handle();
+
+    $this->assertDatabaseHas('user_subscriptions', [
+        'stripe_subscription_id' => 'sub_fail',
+        'payment_status' => 'failed',
+    ]);
+});

--- a/tests/Feature/StripeJobsTest.php
+++ b/tests/Feature/StripeJobsTest.php
@@ -10,8 +10,17 @@ use App\Models\User;
 use App\Models\UserSubscription;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Config::set('services.stripe.secret', '');
+});
+
+afterEach(function () {
+    Carbon::setTestNow(); // reset
+});
 
 it('creates or updates user subscription on checkout.session.completed (new subscription)', function (): void {
     Carbon::setTestNow(Carbon::parse('2025-01-01 00:00:00'));
@@ -91,6 +100,9 @@ it('transfers remaining lessons hint on plan switch at checkout.session.complete
         'user_id' => $user->id,
         'plan_id' => $plan->id,
         'remaining_lessons' => 6,
+        'current_month_used_count' => 0,
+        'status' => 'active',
+        'payment_status' => 'paid',
     ]);
 });
 
@@ -136,6 +148,8 @@ it('updates status and period on customer.subscription.updated', function (): vo
     $this->assertDatabaseHas('user_subscriptions', [
         'stripe_subscription_id' => 'sub_upd',
         'status' => 'past_due',
+        'current_period_start' => Carbon::createFromTimestamp($start),
+        'current_period_end' => Carbon::createFromTimestamp($end),
     ]);
 });
 

--- a/tests/Feature/WebhookListenerTest.php
+++ b/tests/Feature/WebhookListenerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Jobs\ProcessCheckoutSessionCompleted;
+use App\Jobs\ProcessCustomerSubscriptionDeleted;
+use App\Jobs\ProcessCustomerSubscriptionUpdated;
+use App\Jobs\ProcessInvoicePaid;
+use App\Jobs\ProcessInvoicePaymentFailed;
+use App\Listeners\StripeWebhookListener;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Cashier\Events\WebhookReceived;
+
+it('dispatches jobs for allowed event types', function (): void {
+    Bus::fake();
+
+    $listener = app(StripeWebhookListener::class);
+
+    $events = [
+        'checkout.session.completed' => ProcessCheckoutSessionCompleted::class,
+        'customer.subscription.created' => ProcessCustomerSubscriptionUpdated::class,
+        'customer.subscription.updated' => ProcessCustomerSubscriptionUpdated::class,
+        'customer.subscription.deleted' => ProcessCustomerSubscriptionDeleted::class,
+        'invoice.payment_succeeded' => ProcessInvoicePaid::class,
+        'invoice.payment_failed' => ProcessInvoicePaymentFailed::class,
+    ];
+
+    foreach ($events as $type => $job) {
+        $payload = ['id' => 'evt_'.uniqid(), 'type' => $type];
+        $listener->handle(new WebhookReceived($payload));
+        Bus::assertDispatched($job);
+    }
+});
+
+it('ignores disallowed events', function (): void {
+    Bus::fake();
+
+    $listener = app(StripeWebhookListener::class);
+    $payload = ['id' => 'evt_xxx', 'type' => 'charge.succeeded'];
+
+    $listener->handle(new WebhookReceived($payload));
+
+    Bus::assertNotDispatched(ProcessCheckoutSessionCompleted::class);
+    Bus::assertNotDispatched(ProcessCustomerSubscriptionUpdated::class);
+    Bus::assertNotDispatched(ProcessCustomerSubscriptionDeleted::class);
+    Bus::assertNotDispatched(ProcessInvoicePaid::class);
+    Bus::assertNotDispatched(ProcessInvoicePaymentFailed::class);
+});
+
+it('enforces idempotency using cache for duplicate events', function (): void {
+    Bus::fake();
+
+    $listener = app(StripeWebhookListener::class);
+    $eventId = 'evt_dup_'.uniqid();
+    $payload = ['id' => $eventId, 'type' => 'invoice.payment_succeeded'];
+
+    // First time: should dispatch and set cache
+    $listener->handle(new WebhookReceived($payload));
+    Bus::assertDispatched(ProcessInvoicePaid::class);
+
+    // Second time: should be ignored due to idempotency cache
+    Bus::fake();
+    $listener->handle(new WebhookReceived($payload));
+    Bus::assertNotDispatched(ProcessInvoicePaid::class);
+
+    // Cleanup
+    Cache::forget('stripe_webhook:processed:'.$eventId);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Stripeサブスクリプション関連Webhookの自動処理を追加（チェックアウト完了・サブスク作成/更新/削除・請求成功/失敗を非同期ジョブで反映）
  - プラン切替時の残りレッスン引継ぎと初期残数設定

- **バグ修正／改善**
  - Webhook処理での重複排除（idempotency）とエラー時のログ／再試行対応
  - 価格照会APIで失敗や無効な価格を422で返すよう改善

- **テスト**
  - Webhookリスナーと各イベント処理の包括的な自動テストを追加

- **雑務**
  - タスク一覧の完了フラグを更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->