### PR TITLE
feat: LessonScheduleに予約可否判定と原子的予約APIを追加

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -391,7 +391,7 @@
   - Dependencies: None / 依存関係: なし
   - Estimated time: 20 minutes / 推定時間: 20分
 
-- [ ] 35. Extend LessonSchedule model / LessonScheduleモデルを拡張
+- [x] 35. Extend LessonSchedule model / LessonScheduleモデルを拡張
   - File: app/Models/LessonSchedule.php (modify) / ファイル: app/Models/LessonSchedule.php (修正)
   - Add reservations relationship / 予約リレーションを追加
   - Add availability checking methods / 空き状況チェックメソッドを追加

--- a/app/Models/LessonSchedule.php
+++ b/app/Models/LessonSchedule.php
@@ -264,12 +264,12 @@ class LessonSchedule extends Model
     {
         $lesson = $this->lesson;
         if (! $lesson) {
-            return ['success' => false, 'errors' => ['予約対象のレッスンが見つかりません。']];
+            return ['success' => false, 'errors' => [trans('reservation.errors.reservation_lesson_missing')]];
         }
 
         $sub = $subscription ?: $this->findEligibleSubscriptionFor($user);
         if (! $sub) {
-            return ['success' => false, 'errors' => ['有効なサブスクリプションがありません。']];
+            return ['success' => false, 'errors' => [trans('reservation.errors.subscription_missing')]];
         }
 
         return Reservation::createWithValidation([

--- a/app/Models/LessonSchedule.php
+++ b/app/Models/LessonSchedule.php
@@ -166,4 +166,117 @@ class LessonSchedule extends Model
             ->overlapping($startAt, $endAt)
             ->exists();
     }
+
+    /**
+     * Get the capacity for this schedule (delegated from the lesson).
+     */
+    public function capacity(): int
+    {
+        return (int) ($this->lesson?->capacity ?? 0);
+    }
+
+    /**
+     * Calculate the booking deadline datetime based on the lesson's policy.
+     */
+    public function bookingDeadlineAt(): ?Carbon
+    {
+        if (! $this->lesson) {
+            return null;
+        }
+
+        $hours = max(0, (int) ($this->lesson->booking_deadline_hours ?? 0));
+
+        return $this->start_datetime?->copy()->subHours($hours);
+    }
+
+    /**
+     * Determine whether the booking deadline has already passed.
+     */
+    public function hasBookingDeadlinePassed(): bool
+    {
+        $deadline = $this->bookingDeadlineAt();
+        if ($deadline === null) {
+            // 関連欠損時は安全側で締切とみなす
+            return true;
+        }
+
+        return now()->gt($deadline);
+    }
+
+    /**
+     * Determine whether a given subscription can book this schedule.
+     */
+    public function canBookWithSubscription(UserSubscription $subscription): bool
+    {
+        if (! $this->is_active) {
+            return false;
+        }
+
+        if ($this->hasBookingDeadlinePassed()) {
+            return false;
+        }
+
+        if (! $this->hasAvailableSpots()) {
+            return false;
+        }
+
+        $lesson = $this->lesson;
+        if (! $lesson) {
+            return false;
+        }
+
+        return $subscription->canBookLesson($lesson);
+    }
+
+    /**
+     * Find an eligible active & paid subscription of the user that allows this schedule's lesson category.
+     */
+    public function findEligibleSubscriptionFor(User $user): ?UserSubscription
+    {
+        $lesson = $this->lesson;
+        if (! $lesson) {
+            return null;
+        }
+
+        return $user->getActiveSubscriptionForCategory((int) $lesson->category_id);
+    }
+
+    /**
+     * Check if the given user can book this schedule (using their best eligible subscription).
+     */
+    public function canUserBook(User $user): bool
+    {
+        $subscription = $this->findEligibleSubscriptionFor($user);
+        if (! $subscription) {
+            return false;
+        }
+
+        return $this->canBookWithSubscription($subscription);
+    }
+
+    /**
+     * Atomically create a reservation for the given user and optional subscription.
+     * Uses Reservation::createWithValidation() which performs locking and counters update.
+     *
+     * @return array{success:bool, reservation?:\App\Models\Reservation, errors?:list<string>}
+     */
+    public function createReservationForUser(User $user, ?UserSubscription $subscription = null): array
+    {
+        $lesson = $this->lesson;
+        if (! $lesson) {
+            return ['success' => false, 'errors' => ['予約対象のレッスンが見つかりません。']];
+        }
+
+        $sub = $subscription ?: $this->findEligibleSubscriptionFor($user);
+        if (! $sub) {
+            return ['success' => false, 'errors' => ['有効なサブスクリプションがありません。']];
+        }
+
+        return Reservation::createWithValidation([
+            'user_id' => $user->getKey(),
+            'lesson_schedule_id' => $this->getKey(),
+            'user_subscription_id' => $sub->getKey(),
+            // reserved_at はメソッド側で now() セット（省略可）
+        ]);
+    }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -189,7 +189,7 @@ class Reservation extends Model
                 ->exists();
 
             if ($exists) {
-                $errors[] = '同じレッスン枠に既に予約があります。';
+                $errors[] = trans('reservation.errors.duplicate_active_reservation');
             }
         }
 
@@ -197,15 +197,15 @@ class Reservation extends Model
         if (! $this->canBeCreated()) {
             $lesson = $this->lessonSchedule?->lesson;
             if (! $this->userSubscription || ! $lesson || ! $this->userSubscription->canBookLesson($lesson)) {
-                $errors[] = 'サブスクリプションが無効であるか、利用可能なレッスン回数がありません。';
+                $errors[] = trans('reservation.errors.subscription_invalid_or_no_remaining');
             }
 
             if ($this->hasBookingDeadlinePassed()) {
-                $errors[] = '予約受付期限を過ぎています。';
+                $errors[] = trans('reservation.errors.booking_deadline_passed');
             }
 
             if (! $this->lessonSchedule || ! $this->lessonSchedule->hasAvailableSpots()) {
-                $errors[] = 'このレッスンは満員です。';
+                $errors[] = trans('reservation.errors.lesson_full');
             }
         }
 
@@ -241,29 +241,29 @@ class Reservation extends Model
                     ->first();
 
                 if (! $lockedSchedule || ! $lockedSubscription) {
-                    return ['success' => false, 'errors' => ['予約対象のデータが見つかりません。']];
+                    return ['success' => false, 'errors' => [trans('reservation.errors.target_not_found')]];
                 }
 
                 $lesson = $lockedSchedule->lesson;
 
                 // 所有者整合（他人のサブスク悪用防止）
                 if ((int) $lockedSubscription->user_id !== (int) $reservation->user_id) {
-                    return ['success' => false, 'errors' => ['サブスクリプションの所有者が一致しません。']];
+                    return ['success' => false, 'errors' => [trans('reservation.errors.subscription_owner_mismatch')]];
                 }
 
                 // ロック下での受付期限再確認
                 $bookingHours = max(0, (int) ($lesson->booking_deadline_hours ?? 0));
                 $bookingDeadline = $lockedSchedule->start_datetime->copy()->subHours($bookingHours);
                 if (now()->gt($bookingDeadline)) {
-                    return ['success' => false, 'errors' => ['予約受付期限を過ぎています。']];
+                    return ['success' => false, 'errors' => [trans('reservation.errors.booking_deadline_passed')]];
                 }
 
                 // Re-validate under locks
                 if (! $lockedSchedule->hasAvailableSpots()) {
-                    return ['success' => false, 'errors' => ['このレッスンは満員です。']];
+                    return ['success' => false, 'errors' => [trans('reservation.errors.lesson_full')]];
                 }
                 if (! $lockedSubscription->canBookLesson($lesson)) {
-                    return ['success' => false, 'errors' => ['利用可能なレッスン回数がありません。']];
+                    return ['success' => false, 'errors' => [trans('reservation.errors.no_remaining_lessons')]];
                 }
 
                 // Set safe defaults if not provided
@@ -294,15 +294,15 @@ class Reservation extends Model
         } catch (\Illuminate\Database\QueryException $e) {
             // Unique constraint violation (SQLSTATE 23000)
             if ((string) $e->getCode() === '23000') {
-                return ['success' => false, 'errors' => ['同じレッスン枠に既に予約があります。']];
+                return ['success' => false, 'errors' => [trans('reservation.errors.duplicate_active_reservation')]];
             }
             report($e);
 
-            return ['success' => false, 'errors' => ['予約処理中にエラーが発生しました。時間をおいて再度お試しください。']];
+            return ['success' => false, 'errors' => [trans('reservation.errors.generic_failure')]];
         } catch (\Throwable $e) {
             report($e);
 
-            return ['success' => false, 'errors' => ['予約処理中にエラーが発生しました。時間をおいて再度お試しください。']];
+            return ['success' => false, 'errors' => [trans('reservation.errors.generic_failure')]];
         }
     }
 
@@ -315,7 +315,7 @@ class Reservation extends Model
             return \Illuminate\Support\Facades\DB::transaction(function () {
                 // Requirement 8.4: Check cancel deadline and permissions
                 if (! $this->canBeCanceled()) {
-                    return ['success' => false, 'error' => 'キャンセル期限を過ぎているため、キャンセルできません。'];
+                    return ['success' => false, 'error' => trans('reservation.errors.cancel_deadline_passed')];
                 }
 
                 // Update status (avoid mass-assignment; status is not fillable)
@@ -370,7 +370,7 @@ class Reservation extends Model
         } catch (\Throwable $e) {
             report($e);
 
-            return ['success' => false, 'error' => 'キャンセル処理中にエラーが発生しました。'];
+            return ['success' => false, 'error' => trans('reservation.errors.cancel_generic_failure')];
         }
     }
 }

--- a/resources/lang/ja/reservation.php
+++ b/resources/lang/ja/reservation.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'errors' => [
+        'duplicate_active_reservation' => '同じレッスン枠に既に予約があります。',
+        'subscription_invalid_or_no_remaining' => 'サブスクリプションが無効であるか、利用可能なレッスン回数がありません。',
+        'booking_deadline_passed' => '予約受付期限を過ぎています。',
+        'lesson_full' => 'このレッスンは満員です。',
+        'target_not_found' => '予約対象のデータが見つかりません。',
+        'subscription_owner_mismatch' => 'サブスクリプションの所有者が一致しません。',
+        'no_remaining_lessons' => '利用可能なレッスン回数がありません。',
+        'generic_failure' => '予約処理中にエラーが発生しました。時間をおいて再度お試しください。',
+        'cancel_deadline_passed' => 'キャンセル期限を過ぎているため、キャンセルできません。',
+        'cancel_generic_failure' => 'キャンセル処理中にエラーが発生しました。',
+        'reservation_lesson_missing' => '予約対象のレッスンが見つかりません。',
+        'subscription_missing' => '有効なサブスクリプションがありません。',
+    ],
+];
+
+

--- a/resources/lang/ja/reservation.php
+++ b/resources/lang/ja/reservation.php
@@ -16,5 +16,3 @@ return [
         'subscription_missing' => '有効なサブスクリプションがありません。',
     ],
 ];
-
-


### PR DESCRIPTION
- capacity/締切計算/締切判定メソッドを追加
- サブスク整合・空席・締切を考慮したcanBook系を実装
- Reservation::createWithValidationを利用した原子的予約作成を追加
- 既存モデル（Reservation/UserSubscription/Lesson）と整合性を確保

Refs: Task 35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 予約締切、定員、サブスクリプション適合性を総合判定して予約可否を判断するロジックを追加。
  - 安全な予約作成フローを導入し、失敗時に詳細なエラー情報を返却。

- ドキュメント（ローカリゼーション）
  - 予約関連のエラーメッセージを日本語化し、利用者向け表示を翻訳対応で統一。

- 雑務
  - 予約システムのタスク進捗を更新（拡張作業を完了として反映）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->