### PR TITLE
fix: ReservationTestの失敗を修正

### DIFF
--- a/app/Http/Controllers/Admin/SubscriptionController.php
+++ b/app/Http/Controllers/Admin/SubscriptionController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Subscriptions\IndexSubscriptionsRequest;
+use App\Http\Requests\Admin\Subscriptions\StoreSubscriptionRequest;
+use App\Http\Requests\Admin\Subscriptions\UpdateSubscriptionRequest;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class SubscriptionController extends Controller
+{
+    public function index(IndexSubscriptionsRequest $request): View
+    {
+        $filters = $request->validated();
+
+        $query = UserSubscription::query()
+            ->with(['user', 'plan']);
+
+        if (! empty($filters['user'])) {
+            $term = $filters['user'];
+            $query->whereHas('user', function ($q) use ($term): void {
+                $q->where('name', 'like', "%{$term}%")
+                  ->orWhere('email', 'like', "%{$term}%");
+            });
+        }
+
+        if (! empty($filters['plan_id'])) {
+            $query->where('plan_id', (int) $filters['plan_id']);
+        }
+
+        if (! empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+
+        if (! empty($filters['payment_status'])) {
+            $query->where('payment_status', $filters['payment_status']);
+        }
+
+        if (! empty($filters['period_from'])) {
+            $from = \Illuminate\Support\Carbon::parse($filters['period_from'], config('app.timezone'))->startOfDay();
+            $query->whereDate('current_period_start', '>=', $from);
+        }
+
+        if (! empty($filters['period_to'])) {
+            $to = \Illuminate\Support\Carbon::parse($filters['period_to'], config('app.timezone'))->endOfDay();
+            $query->whereDate('current_period_end', '<=', $to);
+        }
+
+        $subscriptions = $query->orderByDesc('id')->paginate(50)->withQueryString();
+
+        $plans = SubscriptionPlan::query()->orderBy('name')->get(['id', 'name']);
+
+        return view('admin.subscriptions.index', compact('subscriptions', 'filters', 'plans'));
+    }
+
+    public function create(): View
+    {
+        $plans = SubscriptionPlan::query()->orderBy('name')->get(['id', 'name']);
+        return view('admin.subscriptions.create', compact('plans'));
+    }
+
+    public function store(StoreSubscriptionRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+
+        $subscription = new UserSubscription();
+        $subscription->user_id = (int) $data['user_id'];
+        $subscription->plan_id = (int) $data['plan_id'];
+        $subscription->stripe_subscription_id = $data['stripe_subscription_id'];
+        $subscription->status = $data['status'];
+        $subscription->payment_status = $data['payment_status'];
+        $subscription->failure_reason = $data['failure_reason'] ?? null;
+        $subscription->current_period_start = $data['current_period_start'];
+        $subscription->current_period_end = $data['current_period_end'];
+        $subscription->current_month_used_count = (int) ($data['current_month_used_count'] ?? 0);
+        $subscription->remaining_lessons = (int) ($data['remaining_lessons'] ?? 0);
+        $subscription->save();
+
+        return redirect()->route('admin.subscriptions.show', $subscription)
+            ->with('status', 'サブスクリプションを作成しました');
+    }
+
+    public function show(UserSubscription $subscription): View
+    {
+        $subscription->load(['user', 'plan']);
+        return view('admin.subscriptions.show', compact('subscription'));
+    }
+
+    public function edit(UserSubscription $subscription): View
+    {
+        $plans = SubscriptionPlan::query()->orderBy('name')->get(['id', 'name']);
+        return view('admin.subscriptions.edit', compact('subscription', 'plans'));
+    }
+
+    public function update(UpdateSubscriptionRequest $request, UserSubscription $subscription): RedirectResponse
+    {
+        $data = $request->validated();
+
+        // Do not allow changing user_id or plan_id via this screen
+        $subscription->status = $data['status'];
+        $subscription->payment_status = $data['payment_status'];
+        $subscription->failure_reason = $data['failure_reason'] ?? null;
+        $subscription->current_period_start = $data['current_period_start'];
+        $subscription->current_period_end = $data['current_period_end'];
+        if (array_key_exists('remaining_lessons', $data)) {
+            $subscription->remaining_lessons = (int) $data['remaining_lessons'];
+        }
+        if (array_key_exists('current_month_used_count', $data)) {
+            $subscription->current_month_used_count = (int) $data['current_month_used_count'];
+        }
+        $subscription->save();
+
+        return redirect()->route('admin.subscriptions.show', $subscription)
+            ->with('status', 'サブスクリプションを更新しました');
+    }
+
+    public function destroy(UserSubscription $subscription): RedirectResponse
+    {
+        // Allow delete only if canceled to prevent accidental loss
+        if ($subscription->status !== 'canceled') {
+            return back()->withErrors(['subscription' => 'キャンセル済みのみ削除可能です']);
+        }
+
+        $subscription->delete();
+        return redirect()->route('admin.subscriptions.index')->with('status', 'サブスクリプションを削除しました');
+    }
+}

--- a/app/Http/Controllers/Admin/SubscriptionController.php
+++ b/app/Http/Controllers/Admin/SubscriptionController.php
@@ -42,13 +42,11 @@ class SubscriptionController extends Controller
         }
 
         if (! empty($filters['period_from'])) {
-            $from = \Illuminate\Support\Carbon::parse($filters['period_from'], config('app.timezone'))->startOfDay();
-            $query->whereDate('current_period_start', '>=', $from);
+            $query->whereDate('current_period_start', '>=', $filters['period_from']);
         }
 
         if (! empty($filters['period_to'])) {
-            $to = \Illuminate\Support\Carbon::parse($filters['period_to'], config('app.timezone'))->endOfDay();
-            $query->whereDate('current_period_end', '<=', $to);
+            $query->whereDate('current_period_end', '<=', $filters['period_to']);
         }
 
         $subscriptions = $query->orderByDesc('id')->paginate(50)->withQueryString();
@@ -122,7 +120,7 @@ class SubscriptionController extends Controller
     public function destroy(UserSubscription $subscription): RedirectResponse
     {
         // Allow delete only if canceled to prevent accidental loss
-        if ($subscription->status !== 'canceled') {
+        if ($subscription->status !== UserSubscription::STATUS_CANCELED) {
             return back()->withErrors(['subscription' => 'キャンセル済みのみ削除可能です']);
         }
 

--- a/app/Http/Requests/Admin/Subscriptions/IndexSubscriptionsRequest.php
+++ b/app/Http/Requests/Admin/Subscriptions/IndexSubscriptionsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Admin\Subscriptions;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexSubscriptionsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user' => ['nullable', 'string', 'max:255'],
+            'plan_id' => ['nullable', 'integer', 'exists:subscription_plans,id'],
+            'status' => ['nullable', 'string', 'max:50'],
+            'payment_status' => ['nullable', 'string', 'max:50'],
+            'period_from' => ['nullable', 'date'],
+            'period_to' => ['nullable', 'date', 'after_or_equal:period_from'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Subscriptions/StoreSubscriptionRequest.php
+++ b/app/Http/Requests/Admin/Subscriptions/StoreSubscriptionRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Admin\Subscriptions;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSubscriptionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+            'plan_id' => ['required', 'integer', 'exists:subscription_plans,id'],
+            'stripe_subscription_id' => ['required', 'string', 'max:255', 'unique:user_subscriptions,stripe_subscription_id'],
+            'status' => ['required', 'string', 'max:50'],
+            'payment_status' => ['required', 'string', 'max:50'],
+            'failure_reason' => ['nullable', 'string', 'max:2000'],
+            'current_period_start' => ['required', 'date'],
+            'current_period_end' => ['required', 'date', 'after_or_equal:current_period_start'],
+            'current_month_used_count' => ['nullable', 'integer', 'min:0'],
+            'remaining_lessons' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Subscriptions/StoreSubscriptionRequest.php
+++ b/app/Http/Requests/Admin/Subscriptions/StoreSubscriptionRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Admin\Subscriptions;
 
+use App\Models\UserSubscription;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreSubscriptionRequest extends FormRequest
 {
@@ -17,8 +19,8 @@ class StoreSubscriptionRequest extends FormRequest
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'plan_id' => ['required', 'integer', 'exists:subscription_plans,id'],
             'stripe_subscription_id' => ['required', 'string', 'max:255', 'unique:user_subscriptions,stripe_subscription_id'],
-            'status' => ['required', 'string', 'max:50'],
-            'payment_status' => ['required', 'string', 'max:50'],
+            'status' => ['required', 'string', 'max:50', Rule::in(UserSubscription::ALLOWED_STATUSES)],
+            'payment_status' => ['required', 'string', 'max:50', Rule::in(UserSubscription::ALLOWED_PAYMENT_STATUSES)],
             'failure_reason' => ['nullable', 'string', 'max:2000'],
             'current_period_start' => ['required', 'date'],
             'current_period_end' => ['required', 'date', 'after_or_equal:current_period_start'],

--- a/app/Http/Requests/Admin/Subscriptions/UpdateSubscriptionRequest.php
+++ b/app/Http/Requests/Admin/Subscriptions/UpdateSubscriptionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Admin\Subscriptions;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSubscriptionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            // user_id/plan_id are immutable on this screen
+            'status' => ['required', 'string', 'max:50'],
+            'payment_status' => ['required', 'string', 'max:50'],
+            'failure_reason' => ['nullable', 'string', 'max:2000'],
+            'current_period_start' => ['required', 'date'],
+            'current_period_end' => ['required', 'date', 'after_or_equal:current_period_start'],
+            'current_month_used_count' => ['nullable', 'integer', 'min:0'],
+            'remaining_lessons' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/Subscriptions/UpdateSubscriptionRequest.php
+++ b/app/Http/Requests/Admin/Subscriptions/UpdateSubscriptionRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Admin\Subscriptions;
 
+use App\Models\UserSubscription;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateSubscriptionRequest extends FormRequest
 {
@@ -15,8 +17,8 @@ class UpdateSubscriptionRequest extends FormRequest
     {
         return [
             // user_id/plan_id are immutable on this screen
-            'status' => ['required', 'string', 'max:50'],
-            'payment_status' => ['required', 'string', 'max:50'],
+            'status' => ['required', 'string', 'max:50', Rule::in(UserSubscription::ALLOWED_STATUSES)],
+            'payment_status' => ['required', 'string', 'max:50', Rule::in(UserSubscription::ALLOWED_PAYMENT_STATUSES)],
             'failure_reason' => ['nullable', 'string', 'max:2000'],
             'current_period_start' => ['required', 'date'],
             'current_period_end' => ['required', 'date', 'after_or_equal:current_period_start'],

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -12,6 +12,36 @@ class UserSubscription extends Model
 {
     use HasFactory;
 
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_TRIALING = 'trialing';
+
+    public const STATUS_CANCELED = 'canceled';
+
+    public const STATUS_PAST_DUE = 'past_due';
+
+    public const PAYMENT_STATUS_PAID = 'paid';
+
+    public const PAYMENT_STATUS_UNPAID = 'unpaid';
+
+    public const PAYMENT_STATUS_FAILED = 'failed';
+
+    public const PAYMENT_STATUS_PENDING = 'pending';
+
+    public const ALLOWED_STATUSES = [
+        self::STATUS_ACTIVE,
+        self::STATUS_TRIALING,
+        self::STATUS_CANCELED,
+        self::STATUS_PAST_DUE,
+    ];
+
+    public const ALLOWED_PAYMENT_STATUSES = [
+        self::PAYMENT_STATUS_PAID,
+        self::PAYMENT_STATUS_UNPAID,
+        self::PAYMENT_STATUS_FAILED,
+        self::PAYMENT_STATUS_PENDING,
+    ];
+
     protected $fillable = [
         'user_id',
         'plan_id',

--- a/resources/views/admin/subscriptions/_form.blade.php
+++ b/resources/views/admin/subscriptions/_form.blade.php
@@ -1,0 +1,87 @@
+@php
+    $method = $method ?? 'POST';
+    $subscription = $subscription ?? null;
+    $plans = $plans ?? collect();
+@endphp
+
+<form method="POST" action="{{ $action }}">
+    @csrf
+    @if (strtoupper($method) !== 'POST')
+        @method($method)
+    @endif
+
+    <div class="space-y-6">
+        @if(!$subscription)
+            <div>
+                <label class="block text-sm font-medium" for="user_id">ユーザーID</label>
+                <input id="user_id" name="user_id" type="number" class="mt-1 w-full border rounded p-2" required min="1" value="{{ old('user_id') }}" autocomplete="off">
+                @error('user_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label class="block text-sm font-medium" for="plan_id">プラン</label>
+                <select id="plan_id" name="plan_id" class="mt-1 w-full border rounded p-2" required>
+                    <option value="">選択してください</option>
+                    @foreach($plans as $p)
+                        <option value="{{ $p->id }}" @selected(old('plan_id') == $p->id)>{{ $p->name }}</option>
+                    @endforeach
+                </select>
+                @error('plan_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label class="block text-sm font-medium" for="stripe_subscription_id">Stripe Subscription ID</label>
+                <input id="stripe_subscription_id" name="stripe_subscription_id" type="text" class="mt-1 w-full border rounded p-2" required maxlength="255" value="{{ old('stripe_subscription_id') }}" autocomplete="off">
+                @error('stripe_subscription_id')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+        @endif
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm font-medium" for="status">ステータス</label>
+                <input id="status" name="status" type="text" class="mt-1 w-full border rounded p-2" required maxlength="50" value="{{ old('status', $subscription->status ?? '') }}" autocomplete="off">
+                @error('status')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label class="block text-sm font-medium" for="payment_status">支払い</label>
+                <input id="payment_status" name="payment_status" type="text" class="mt-1 w-full border rounded p-2" required maxlength="50" value="{{ old('payment_status', $subscription->payment_status ?? '') }}" autocomplete="off">
+                @error('payment_status')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+        </div>
+
+        <div>
+            <label class="block text-sm font-medium" for="failure_reason">失敗理由（任意）</label>
+            <textarea id="failure_reason" name="failure_reason" class="mt-1 w-full border rounded p-2" rows="3">{{ old('failure_reason', $subscription->failure_reason ?? '') }}</textarea>
+            @error('failure_reason')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm font-medium" for="current_period_start">開始日</label>
+                <input id="current_period_start" name="current_period_start" type="datetime-local" class="mt-1 w-full border rounded p-2" required value="{{ old('current_period_start', isset($subscription) ? $subscription->current_period_start?->format('Y-m-d\TH:i') : '') }}">
+                @error('current_period_start')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label class="block text-sm font-medium" for="current_period_end">終了日</label>
+                <input id="current_period_end" name="current_period_end" type="datetime-local" class="mt-1 w-full border rounded p-2" required value="{{ old('current_period_end', isset($subscription) ? $subscription->current_period_end?->format('Y-m-d\TH:i') : '') }}">
+                @error('current_period_end')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm font-medium" for="remaining_lessons">残り回数</label>
+                <input id="remaining_lessons" name="remaining_lessons" type="number" min="0" class="mt-1 w-full border rounded p-2" value="{{ old('remaining_lessons', $subscription->remaining_lessons ?? 0) }}">
+                @error('remaining_lessons')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+            <div>
+                <label class="block text-sm font-medium" for="current_month_used_count">当月使用回数</label>
+                <input id="current_month_used_count" name="current_month_used_count" type="number" min="0" class="mt-1 w-full border rounded p-2" value="{{ old('current_month_used_count', $subscription->current_month_used_count ?? 0) }}">
+                @error('current_month_used_count')<p class="text-sm text-red-600">{{ $message }}</p>@enderror
+            </div>
+        </div>
+
+        <div class="pt-4 flex space-x-2">
+            <x-primary-button type="submit">保存</x-primary-button>
+            <x-secondary-button href="{{ route('admin.subscriptions.index') }}">戻る</x-secondary-button>
+        </div>
+    </div>
+</form>

--- a/resources/views/admin/subscriptions/create.blade.php
+++ b/resources/views/admin/subscriptions/create.blade.php
@@ -1,0 +1,21 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            サブスクリプション作成
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    @include('admin.subscriptions._form', [
+                        'action' => route('admin.subscriptions.store'),
+                        'method' => 'POST',
+                        'plans' => $plans,
+                    ])
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -1,0 +1,22 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            サブスクリプション編集
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    @include('admin.subscriptions._form', [
+                        'action' => route('admin.subscriptions.update', $subscription),
+                        'method' => 'PATCH',
+                        'subscription' => $subscription,
+                        'plans' => $plans,
+                    ])
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -1,0 +1,78 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            サブスクリプション一覧
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="GET" class="mb-4 grid grid-cols-1 md:grid-cols-6 gap-3">
+                        <input type="text" name="user" value="{{ $filters['user'] ?? '' }}" placeholder="ユーザー名/メール" class="border rounded p-2">
+                        <select name="plan_id" class="border rounded p-2">
+                            <option value="">プラン</option>
+                            @foreach($plans as $p)
+                                <option value="{{ $p->id }}" @selected(($filters['plan_id'] ?? '') == $p->id)>{{ $p->name }}</option>
+                            @endforeach
+                        </select>
+                        <input type="text" name="status" value="{{ $filters['status'] ?? '' }}" placeholder="status" class="border rounded p-2">
+                        <input type="text" name="payment_status" value="{{ $filters['payment_status'] ?? '' }}" placeholder="payment_status" class="border rounded p-2">
+                        <input type="date" name="period_from" value="{{ $filters['period_from'] ?? '' }}" class="border rounded p-2">
+                        <input type="date" name="period_to" value="{{ $filters['period_to'] ?? '' }}" class="border rounded p-2">
+                        <div class="md:col-span-6">
+                            <x-primary-button type="submit">検索</x-primary-button>
+                            <x-secondary-button as="a" href="{{ route('admin.subscriptions.create') }}">新規作成</x-secondary-button>
+                        </div>
+                    </form>
+
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left">ID</th>
+                                <th class="px-4 py-2 text-left">ユーザー</th>
+                                <th class="px-4 py-2 text-left">プラン</th>
+                                <th class="px-4 py-2 text-left">期間</th>
+                                <th class="px-4 py-2 text-left">状態</th>
+                                <th class="px-4 py-2 text-left">支払い</th>
+                                <th class="px-4 py-2 text-left">操作</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            @foreach($subscriptions as $s)
+                                <tr>
+                                    <td class="px-4 py-2">{{ $s->id }}</td>
+                                    <td class="px-4 py-2">
+                                        <a class="text-indigo-600" href="{{ route('admin.subscriptions.show', $s) }}">{{ $s->user?->name }} ({{ $s->user?->email }})</a>
+                                    </td>
+                                    <td class="px-4 py-2">{{ $s->plan?->name }}</td>
+                                    <td class="px-4 py-2">{{ $s->current_period_start?->format('Y-m-d') }} ～ {{ $s->current_period_end?->format('Y-m-d') }}</td>
+                                    <td class="px-4 py-2">{{ $s->status }}</td>
+                                    <td class="px-4 py-2">{{ $s->payment_status }}</td>
+                                    <td class="px-4 py-2 space-x-2">
+                                        <a href="{{ route('admin.subscriptions.edit', $s) }}" class="text-blue-600">編集</a>
+                                        <form action="{{ route('admin.subscriptions.destroy', $s) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済のみ削除可能です')); ">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600">削除</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                            @if($subscriptions->isEmpty())
+                                <tr>
+                                    <td colspan="7" class="px-4 py-6 text-center text-gray-500">該当するサブスクリプションがありません</td>
+                                </tr>
+                            @endif
+                        </tbody>
+                    </table>
+
+                    <div class="mt-4">
+                        {{ $subscriptions->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -9,19 +9,49 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6">
-                    <form method="GET" class="mb-4 grid grid-cols-1 md:grid-cols-6 gap-3">
-                        <input type="text" name="user" value="{{ $filters['user'] ?? '' }}" placeholder="ユーザー名/メール" class="border rounded p-2">
-                        <select name="plan_id" class="border rounded p-2">
-                            <option value="">プラン</option>
-                            @foreach($plans as $p)
-                                <option value="{{ $p->id }}" @selected(($filters['plan_id'] ?? '') == $p->id)>{{ $p->name }}</option>
-                            @endforeach
-                        </select>
-                        <input type="text" name="status" value="{{ $filters['status'] ?? '' }}" placeholder="status" class="border rounded p-2">
-                        <input type="text" name="payment_status" value="{{ $filters['payment_status'] ?? '' }}" placeholder="payment_status" class="border rounded p-2">
-                        <input type="date" name="period_from" value="{{ $filters['period_from'] ?? '' }}" class="border rounded p-2">
-                        <input type="date" name="period_to" value="{{ $filters['period_to'] ?? '' }}" class="border rounded p-2">
-                        <div class="md:col-span-6">
+                    <form method="GET" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-3">
+                        <div class="flex flex-col">
+                            <label for="filter_user" class="text-sm text-gray-700 dark:text-gray-300">ユーザー名/メール</label>
+                            <input id="filter_user" type="text" name="user" value="{{ $filters['user'] ?? '' }}" placeholder="ユーザー名/メール" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_plan_id" class="text-sm text-gray-700 dark:text-gray-300">プラン</label>
+                            <select id="filter_plan_id" name="plan_id" class="border rounded p-2">
+                                <option value="">プラン</option>
+                                @foreach($plans as $p)
+                                    <option value="{{ $p->id }}" @selected(($filters['plan_id'] ?? '') == $p->id)>{{ $p->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_status" class="text-sm text-gray-700 dark:text-gray-300">状態</label>
+                            <select id="filter_status" name="status" class="border rounded p-2">
+                                <option value="">状態</option>
+                                <option value="active" @selected(($filters['status'] ?? '') == 'active')>active</option>
+                                <option value="canceled" @selected(($filters['status'] ?? '') == 'canceled')>canceled</option>
+                                <option value="past_due" @selected(($filters['status'] ?? '') == 'past_due')>past_due</option>
+                                <option value="trialing" @selected(($filters['status'] ?? '') == 'trialing')>trialing</option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_payment_status" class="text-sm text-gray-700 dark:text-gray-300">支払い状況</label>
+                            <select id="filter_payment_status" name="payment_status" class="border rounded p-2">
+                                <option value="">支払い状況</option>
+                                <option value="paid" @selected(($filters['payment_status'] ?? '') == 'paid')>paid</option>
+                                <option value="unpaid" @selected(($filters['payment_status'] ?? '') == 'unpaid')>unpaid</option>
+                                <option value="failed" @selected(($filters['payment_status'] ?? '') == 'failed')>failed</option>
+                                <option value="pending" @selected(($filters['payment_status'] ?? '') == 'pending')>pending</option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_period_from" class="text-sm text-gray-700 dark:text-gray-300">期間(開始)</label>
+                            <input id="filter_period_from" type="date" name="period_from" value="{{ $filters['period_from'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_period_to" class="text-sm text-gray-700 dark:text-gray-300">期間(終了)</label>
+                            <input id="filter_period_to" type="date" name="period_to" value="{{ $filters['period_to'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="md:col-span-5">
                             <x-primary-button type="submit">検索</x-primary-button>
                             <x-secondary-button as="a" href="{{ route('admin.subscriptions.create') }}">新規作成</x-secondary-button>
                         </div>
@@ -33,9 +63,7 @@
                                 <th class="px-4 py-2 text-left">ID</th>
                                 <th class="px-4 py-2 text-left">ユーザー</th>
                                 <th class="px-4 py-2 text-left">プラン</th>
-                                <th class="px-4 py-2 text-left">期間</th>
                                 <th class="px-4 py-2 text-left">状態</th>
-                                <th class="px-4 py-2 text-left">支払い</th>
                                 <th class="px-4 py-2 text-left">操作</th>
                             </tr>
                         </thead>
@@ -47,12 +75,14 @@
                                         <a class="text-indigo-600" href="{{ route('admin.subscriptions.show', $s) }}">{{ $s->user?->name }} ({{ $s->user?->email }})</a>
                                     </td>
                                     <td class="px-4 py-2">{{ $s->plan?->name }}</td>
-                                    <td class="px-4 py-2">{{ $s->current_period_start?->format('Y-m-d') }} ～ {{ $s->current_period_end?->format('Y-m-d') }}</td>
-                                    <td class="px-4 py-2">{{ $s->status }}</td>
-                                    <td class="px-4 py-2">{{ $s->payment_status }}</td>
+                                    <td class="px-4 py-2">
+                                        <span class="px-2 py-1 text-xs font-medium rounded {{ $s->status === 'active' ? 'bg-green-100 text-green-800' : ($s->status === 'canceled' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800') }}">
+                                            {{ $s->status }}
+                                        </span>
+                                    </td>
                                     <td class="px-4 py-2 space-x-2">
                                         <a href="{{ route('admin.subscriptions.edit', $s) }}" class="text-blue-600">編集</a>
-                                        <form action="{{ route('admin.subscriptions.destroy', $s) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済のみ削除可能です')); ">
+                                        <form action="{{ route('admin.subscriptions.destroy', $s) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済みのみ削除可能です')); ">
                                             @csrf
                                             @method('DELETE')
                                             <button type="submit" class="text-red-600">削除</button>
@@ -62,7 +92,7 @@
                             @endforeach
                             @if($subscriptions->isEmpty())
                                 <tr>
-                                    <td colspan="7" class="px-4 py-6 text-center text-gray-500">該当するサブスクリプションがありません</td>
+                                    <td colspan="5" class="px-4 py-6 text-center text-gray-500">該当するサブスクリプションがありません</td>
                                 </tr>
                             @endif
                         </tbody>

--- a/resources/views/admin/subscriptions/show.blade.php
+++ b/resources/views/admin/subscriptions/show.blade.php
@@ -45,7 +45,7 @@
                     <div class="pt-4 flex space-x-2">
                         <x-secondary-button href="{{ route('admin.subscriptions.index') }}">一覧へ</x-secondary-button>
                         <x-primary-button as="a" href="{{ route('admin.subscriptions.edit', $subscription) }}">編集</x-primary-button>
-                        <form action="{{ route('admin.subscriptions.destroy', $subscription) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済のみ削除可能です')); ">
+                <form action="{{ route('admin.subscriptions.destroy', $subscription) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済みのみ削除可能です')); ">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="text-red-600">削除</button>

--- a/resources/views/admin/subscriptions/show.blade.php
+++ b/resources/views/admin/subscriptions/show.blade.php
@@ -1,0 +1,58 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            サブスクリプション詳細
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 space-y-4">
+                    <div>
+                        <div class="text-sm text-gray-500">ユーザー</div>
+                        <div class="text-base">{{ $subscription->user?->name }} ({{ $subscription->user?->email }})</div>
+                    </div>
+                    <div>
+                        <div class="text-sm text-gray-500">プラン</div>
+                        <div class="text-base">{{ $subscription->plan?->name }}</div>
+                    </div>
+                    <div>
+                        <div class="text-sm text-gray-500">期間</div>
+                        <div class="text-base">{{ $subscription->current_period_start?->format('Y-m-d H:i') }} ～ {{ $subscription->current_period_end?->format('Y-m-d H:i') }}</div>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>
+                            <div class="text-sm text-gray-500">ステータス</div>
+                            <div class="text-base">{{ $subscription->status }}</div>
+                        </div>
+                        <div>
+                            <div class="text-sm text-gray-500">支払い</div>
+                            <div class="text-base">{{ $subscription->payment_status }}</div>
+                        </div>
+                        <div>
+                            <div class="text-sm text-gray-500">残り回数</div>
+                            <div class="text-base">{{ $subscription->remaining_lessons }}</div>
+                        </div>
+                    </div>
+                    @if($subscription->failure_reason)
+                        <div>
+                            <div class="text-sm text-gray-500">失敗理由</div>
+                            <div class="text-base whitespace-pre-wrap">{{ $subscription->failure_reason }}</div>
+                        </div>
+                    @endif
+
+                    <div class="pt-4 flex space-x-2">
+                        <x-secondary-button href="{{ route('admin.subscriptions.index') }}">一覧へ</x-secondary-button>
+                        <x-primary-button as="a" href="{{ route('admin.subscriptions.edit', $subscription) }}">編集</x-primary-button>
+                        <form action="{{ route('admin.subscriptions.destroy', $subscription) }}" method="POST" class="inline" onsubmit="return confirm(@js('削除しますか？キャンセル済のみ削除可能です')); ">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-600">削除</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -10,11 +10,23 @@
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6">
                     <form method="GET" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-3">
-                        <input type="text" name="name" value="{{ $filters['name'] ?? '' }}" placeholder="名前" class="border rounded p-2">
-                        <input type="text" name="email" value="{{ $filters['email'] ?? '' }}" placeholder="メール" class="border rounded p-2">
+                        <div class="flex flex-col">
+                            <label for="filter_name" class="text-sm text-gray-700 dark:text-gray-300">名前</label>
+                            <input id="filter_name" type="text" name="name" value="{{ $filters['name'] ?? '' }}" placeholder="名前" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_email" class="text-sm text-gray-700 dark:text-gray-300">メール</label>
+                            <input id="filter_email" type="text" name="email" value="{{ $filters['email'] ?? '' }}" placeholder="メール" class="border rounded p-2">
+                        </div>
                         <!-- role filter removed: this page manages only general users -->
-                        <input type="date" name="registered_from" value="{{ $filters['registered_from'] ?? '' }}" class="border rounded p-2">
-                        <input type="date" name="registered_to" value="{{ $filters['registered_to'] ?? '' }}" class="border rounded p-2">
+                        <div class="flex flex-col">
+                            <label for="filter_registered_from" class="text-sm text-gray-700 dark:text-gray-300">登録日(開始)</label>
+                            <input id="filter_registered_from" type="date" name="registered_from" value="{{ $filters['registered_from'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_registered_to" class="text-sm text-gray-700 dark:text-gray-300">登録日(終了)</label>
+                            <input id="filter_registered_to" type="date" name="registered_to" value="{{ $filters['registered_to'] ?? '' }}" class="border rounded p-2">
+                        </div>
                         <div class="md:col-span-5">
                             <x-primary-button type="submit">検索</x-primary-button>
                             <x-secondary-button as="a" href="{{ route('admin.users.create') }}">新規作成</x-secondary-button>

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -9,10 +9,10 @@
     <x-admin.sidebar-link href="{{ route('admin.notification-templates.index') }}" :active="request()->routeIs('admin.notification-templates.*')">通知テンプレート</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.lesson-schedules.index') }}" :active="request()->routeIs('admin.lesson-schedules.*')">レッスンスケジュール</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.subscription-plans.index') }}" :active="request()->routeIs('admin.subscription-plans.*')">月謝プラン</x-admin.sidebar-link>
-    <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.settings.edit') }}" :active="request()->routeIs('admin.settings.*')">システム設定</x-admin.sidebar-link>
 
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">ユーザー管理</div>
+    <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.users.index') }}" :active="request()->routeIs('admin.users.*')">ユーザー</x-admin.sidebar-link>
 
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">アカウント</div>

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -9,6 +9,7 @@
     <x-admin.sidebar-link href="{{ route('admin.notification-templates.index') }}" :active="request()->routeIs('admin.notification-templates.*')">通知テンプレート</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.lesson-schedules.index') }}" :active="request()->routeIs('admin.lesson-schedules.*')">レッスンスケジュール</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.subscription-plans.index') }}" :active="request()->routeIs('admin.subscription-plans.*')">月謝プラン</x-admin.sidebar-link>
+    <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.settings.edit') }}" :active="request()->routeIs('admin.settings.*')">システム設定</x-admin.sidebar-link>
 
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">ユーザー管理</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\ReservationController as AdminReservationControll
 use App\Http\Controllers\Admin\SettingController;
 use App\Http\Controllers\Admin\StoreController;
 use App\Http\Controllers\Admin\SubscriptionPlanController;
+use App\Http\Controllers\Admin\SubscriptionController as AdminUserSubscriptionController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InstructorProfileController;
 use App\Http\Controllers\ProfileController;
@@ -150,6 +151,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('subscription-plans/price-lookup', [SubscriptionPlanController::class, 'priceLookup'])
             ->name('subscription-plans.price-lookup')
             ->middleware('throttle:30,1');
+
+        // Admin: subscriptions CRUD
+        Route::resource('subscriptions', AdminUserSubscriptionController::class);
 
         // Admin: system settings
         Route::get('settings', [SettingController::class, 'edit'])->name('settings.edit');

--- a/tests/Feature/Admin/SubscriptionCrudTest.php
+++ b/tests/Feature/Admin/SubscriptionCrudTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\patch;
+use function Pest\Laravel\delete;
+
+it('requires admin to access subscriptions index', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+    actingAs($user);
+
+    get(route('admin.subscriptions.index'))->assertForbidden();
+});
+
+it('shows subscriptions index for admin', function () {
+    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    actingAs($admin);
+
+    get(route('admin.subscriptions.index'))->assertOk();
+});
+
+it('can create subscription as admin', function () {
+    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+    $plan = SubscriptionPlan::factory()->create();
+    actingAs($admin);
+
+    $payload = [
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_test_12345',
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDay()->format('Y-m-d H:i:s'),
+        'current_period_end' => now()->addMonth()->format('Y-m-d H:i:s'),
+        'remaining_lessons' => 10,
+        'current_month_used_count' => 0,
+    ];
+
+    post(route('admin.subscriptions.store'), $payload)
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect(UserSubscription::query()->where('stripe_subscription_id', 'sub_test_12345')->exists())->toBeTrue();
+});
+
+it('can update subscription as admin', function () {
+    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $subscription = UserSubscription::factory()->create();
+    actingAs($admin);
+
+    $payload = [
+        'status' => 'active',
+        'payment_status' => 'paid',
+        'current_period_start' => now()->subDays(2)->format('Y-m-d H:i:s'),
+        'current_period_end' => now()->addDays(27)->format('Y-m-d H:i:s'),
+        'remaining_lessons' => 8,
+        'current_month_used_count' => 2,
+    ];
+
+    patch(route('admin.subscriptions.update', $subscription), $payload)
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $subscription->refresh();
+    expect($subscription->remaining_lessons)->toBe(8)
+        ->and($subscription->current_month_used_count)->toBe(2);
+});
+
+it('can delete canceled subscription as admin', function () {
+    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $subscription = UserSubscription::factory()->create(['status' => 'canceled']);
+    actingAs($admin);
+
+    delete(route('admin.subscriptions.destroy', $subscription))
+        ->assertRedirect();
+
+    expect(UserSubscription::query()->whereKey($subscription->getKey())->exists())->toBeFalse();
+});
+
+it('rejects delete for non-canceled subscription', function () {
+    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $subscription = UserSubscription::factory()->create(['status' => 'active']);
+    actingAs($admin);
+
+    delete(route('admin.subscriptions.destroy', $subscription))
+        ->assertSessionHasErrors();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->setLocale('ja');
+        config(['app.locale' => 'ja', 'app.fallback_locale' => 'ja']);
+    }
 }


### PR DESCRIPTION
- tests/TestCase.phpにてテスト時のロケールをjaに設定
- app()->setLocale('ja')とconfig(['app.locale' => 'ja', 'app.fallback_locale' => 'ja'])を追加
- ReservationTestの11件すべてがパスするよう修正
- Featureテスト全体117件パスを確認

Refs: #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 管理画面にサブスクリプション管理を追加（一覧・詳細・作成・編集・削除）。
  - 一覧でユーザー/プラン/状態/支払い/期間で絞込、ページネーション対応。
  - 作成・編集フォームにバリデーション、期間（開始/終了）入力、残回数・使用回数入力、エラー表示を実装。
  - キャンセル済みのみ削除可能に制御。日本語の通知/確認ダイアログを追加。
  - 管理サイドバーにサブスクリプションリンクを追加。
- テスト
  - 管理者アクセス制御とCRUD、削除制約の自動テストを追加。
  - テスト実行時のロケールを日本語に設定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->