### PR TITLE
feat: パーソナルレッスン予約管理画面を作成

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -490,7 +490,7 @@
   - Dependencies: Task 39 / 依存関係: タスク39
   - Estimated time: 55 minutes / 推定時間: 55分
 
-- [ ] 41. Create personal lesson reservation management interface / パーソナルレッスン予約管理画面を作成
+- [x] 41. Create personal lesson reservation management interface / パーソナルレッスン予約管理画面を作成
   - File: app/Http/Controllers/Admin/PersonalReservationController.php (new) / ファイル: app/Http/Controllers/Admin/PersonalReservationController.php (新規)
   - File: resources/views/admin/reservations/personal/ (new directory) / ファイル: resources/views/admin/reservations/personal/ (新規ディレクトリ)
   - Implement personal lesson reservation CRUD operations / パーソナルレッスン予約CRUD操作を実装

--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -492,8 +492,8 @@
 
 - [x] 41. Create personal lesson reservation management interface / パーソナルレッスン予約管理画面を作成
   - File: app/Http/Controllers/Admin/PersonalReservationController.php (new) / ファイル: app/Http/Controllers/Admin/PersonalReservationController.php (新規)
-  - File: resources/views/admin/reservations/personal/ (new directory) / ファイル: resources/views/admin/reservations/personal/ (新規ディレクトリ)
-  - Implement personal lesson reservation CRUD operations / パーソナルレッスン予約CRUD操作を実装
+  - File: resources/views/admin/personal-reservations/ (new directory) / ファイル: resources/views/admin/personal-reservations/ (新規ディレクトリ)
+  - Implement index (filterable listing). Full CRUD is Task 55. / index（フィルタ付き一覧）を実装。CRUD 全量はタスク55。
   - Add reservation search and filtering (instructor, date, status) / 予約検索・フィルタリング機能を追加（インストラクター、日付、ステータス）
   - Add instructor-based filtering with instructor selection tabs / インストラクター選択タブ付きインストラクターベースフィルタリングを追加
   - Add date range filtering with calendar picker / カレンダーピッカー付き日付範囲フィルタリングを追加

--- a/app/Http/Controllers/Admin/PersonalReservationController.php
+++ b/app/Http/Controllers/Admin/PersonalReservationController.php
@@ -31,9 +31,16 @@ class PersonalReservationController extends Controller
         if (! empty($filters['user'])) {
             $term = $filters['user'];
             $query->whereHas('user', function ($uq) use ($term): void {
-                $uq->where(function ($inner) use ($term): void {
-                    $inner->where('name', 'like', "%{$term}%")
-                        ->orWhere('email', 'like', "%{$term}%");
+                $escape = '!';
+                $pattern = '%'.str_replace([
+                    $escape, '%', '_',
+                ], [
+                    $escape.$escape, $escape.'%', $escape.'_',
+                ], $term).'%';
+
+                $uq->where(function ($inner) use ($pattern, $escape): void {
+                    $inner->whereRaw("name LIKE ? ESCAPE '{$escape}'", [$pattern])
+                        ->orWhereRaw("email LIKE ? ESCAPE '{$escape}'", [$pattern]);
                 });
             });
         }
@@ -59,11 +66,13 @@ class PersonalReservationController extends Controller
             ->paginate(50)
             ->withQueryString();
 
-        $instructors = User::query()->where('role', User::ROLE_INSTRUCTOR)->orderBy('name')->get(['id', 'name']);
+        $instructors = User::query()
+            ->where('role', User::ROLE_INSTRUCTOR)
+            ->whereHas('taughtLessons', fn ($q) => $q->where('capacity', 1))
+            ->orderBy('name')
+            ->get(['id', 'name']);
         $lessons = Lesson::query()->where('capacity', 1)->orderBy('name')->get(['id', 'name']);
 
         return view('admin.personal-reservations.index', compact('reservations', 'filters', 'instructors', 'lessons'));
     }
 }
-
-

--- a/app/Http/Controllers/Admin/PersonalReservationController.php
+++ b/app/Http/Controllers/Admin/PersonalReservationController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\PersonalReservations\IndexPersonalReservationsRequest;
+use App\Models\Lesson;
+use App\Models\Reservation;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Carbon;
+
+class PersonalReservationController extends Controller
+{
+    public function index(IndexPersonalReservationsRequest $request): View
+    {
+        $filters = $request->validated();
+
+        $query = Reservation::query()
+            ->with(['user', 'lessonSchedule.lesson.instructor'])
+            ->whereHas('lessonSchedule.lesson', fn ($q) => $q->where('capacity', 1));
+
+        if (! empty($filters['instructor_id'])) {
+            $query->whereHas('lessonSchedule.lesson', fn ($q) => $q->where('instructor_user_id', $filters['instructor_id']));
+        }
+
+        if (! empty($filters['lesson_id'])) {
+            $query->whereHas('lessonSchedule', fn ($q) => $q->where('lesson_id', $filters['lesson_id']));
+        }
+
+        if (! empty($filters['user'])) {
+            $term = $filters['user'];
+            $query->whereHas('user', function ($uq) use ($term): void {
+                $uq->where(function ($inner) use ($term): void {
+                    $inner->where('name', 'like', "%{$term}%")
+                        ->orWhere('email', 'like', "%{$term}%");
+                });
+            });
+        }
+
+        if (! empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+
+        if (! empty($filters['date_from'])) {
+            $from = Carbon::createFromFormat('Y-m-d', $filters['date_from'])->startOfDay();
+            $query->whereHas('lessonSchedule', fn ($q) => $q->where('start_datetime', '>=', $from));
+        }
+        if (! empty($filters['date_to'])) {
+            $to = Carbon::createFromFormat('Y-m-d', $filters['date_to'])->endOfDay();
+            $query->whereHas('lessonSchedule', fn ($q) => $q->where('start_datetime', '<=', $to));
+        }
+
+        $reservations = $query
+            ->join('lesson_schedules', 'lesson_schedules.id', '=', 'reservations.lesson_schedule_id')
+            ->orderByDesc('lesson_schedules.start_datetime')
+            ->orderByDesc('reservations.id')
+            ->select('reservations.*')
+            ->paginate(50)
+            ->withQueryString();
+
+        $instructors = User::query()->where('role', User::ROLE_INSTRUCTOR)->orderBy('name')->get(['id', 'name']);
+        $lessons = Lesson::query()->where('capacity', 1)->orderBy('name')->get(['id', 'name']);
+
+        return view('admin.personal-reservations.index', compact('reservations', 'filters', 'instructors', 'lessons'));
+    }
+}
+
+

--- a/app/Http/Requests/Admin/PersonalReservations/IndexPersonalReservationsRequest.php
+++ b/app/Http/Requests/Admin/PersonalReservations/IndexPersonalReservationsRequest.php
@@ -30,10 +30,8 @@ class IndexPersonalReservationsRequest extends FormRequest
             'lesson_id' => ['nullable', 'integer', 'exists:lessons,id'],
             'user' => ['nullable', 'string', 'max:255'],
             'status' => ['nullable', 'string', Rule::in(Reservation::STATUSES)],
-            'date_from' => ['nullable', 'date', 'date_format:Y-m-d'],
-            'date_to' => ['nullable', 'date', 'date_format:Y-m-d', 'after_or_equal:date_from'],
+            'date_from' => ['nullable', 'date_format:Y-m-d'],
+            'date_to' => ['nullable', 'date_format:Y-m-d', 'after_or_equal:date_from'],
         ];
     }
 }
-
-

--- a/app/Http/Requests/Admin/PersonalReservations/IndexPersonalReservationsRequest.php
+++ b/app/Http/Requests/Admin/PersonalReservations/IndexPersonalReservationsRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Admin\PersonalReservations;
+
+use App\Models\Reservation;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class IndexPersonalReservationsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('access-admin') ?? false;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'instructor_id' => $this->filled('instructor_id') ? (int) $this->input('instructor_id') : null,
+            'lesson_id' => $this->filled('lesson_id') ? (int) $this->input('lesson_id') : null,
+            'user' => is_string($this->input('user')) ? trim($this->input('user')) : null,
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'instructor_id' => ['nullable', 'integer', Rule::exists('users', 'id')->where('role', User::ROLE_INSTRUCTOR)],
+            'lesson_id' => ['nullable', 'integer', 'exists:lessons,id'],
+            'user' => ['nullable', 'string', 'max:255'],
+            'status' => ['nullable', 'string', Rule::in(Reservation::STATUSES)],
+            'date_from' => ['nullable', 'date', 'date_format:Y-m-d'],
+            'date_to' => ['nullable', 'date', 'date_format:Y-m-d', 'after_or_equal:date_from'],
+        ];
+    }
+}
+
+

--- a/resources/views/admin/personal-reservations/index.blade.php
+++ b/resources/views/admin/personal-reservations/index.blade.php
@@ -69,7 +69,7 @@
                         <tbody class="divide-y divide-gray-200">
                             @forelse($reservations as $r)
                                 <tr>
-                                    <td class="px-4 py-2">{{ $r->reserved_at?->format('Y-m-d H:i') ?? '-' }}</td>
+                                    <td class="px-4 py-2">{{ $r->lessonSchedule?->start_datetime?->format('Y-m-d H:i') ?? '-' }}</td>
                                     <td class="px-4 py-2">{{ $r->lessonSchedule?->lesson?->name ?? '-' }}</td>
                                     <td class="px-4 py-2">{{ $r->lessonSchedule?->lesson?->instructor?->name ?? '-' }}</td>
                                     <td class="px-4 py-2">{{ $r->user?->name ?? '-' }} ({{ $r->user?->email ?? '' }})</td>

--- a/resources/views/admin/personal-reservations/index.blade.php
+++ b/resources/views/admin/personal-reservations/index.blade.php
@@ -105,5 +105,3 @@
         </div>
     </div>
 </x-admin-layout>
-
-

--- a/resources/views/admin/personal-reservations/index.blade.php
+++ b/resources/views/admin/personal-reservations/index.blade.php
@@ -1,0 +1,109 @@
+<x-admin-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            パーソナルレッスン予約管理
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="GET" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-3">
+                        <div class="flex flex-col">
+                            <label for="filter_instructor" class="text-sm text-gray-700 dark:text-gray-300">インストラクター</label>
+                            <select id="filter_instructor" name="instructor_id" class="border rounded p-2">
+                                <option value="">すべて</option>
+                                @foreach($instructors as $i)
+                                    <option value="{{ $i->id }}" @selected(($filters['instructor_id'] ?? '') == $i->id)>{{ $i->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_lesson" class="text-sm text-gray-700 dark:text-gray-300">レッスン</label>
+                            <select id="filter_lesson" name="lesson_id" class="border rounded p-2">
+                                <option value="">すべて</option>
+                                @foreach($lessons as $l)
+                                    <option value="{{ $l->id }}" @selected(($filters['lesson_id'] ?? '') == $l->id)>{{ $l->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_user" class="text-sm text-gray-700 dark:text-gray-300">ユーザー名/メール</label>
+                            <input id="filter_user" type="text" name="user" value="{{ $filters['user'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_status" class="text-sm text-gray-700 dark:text-gray-300">状態</label>
+                            <select id="filter_status" name="status" class="border rounded p-2">
+                                <option value="">すべて</option>
+                                <option value="pending" @selected(($filters['status'] ?? '') == 'pending')>pending</option>
+                                <option value="confirmed" @selected(($filters['status'] ?? '') == 'confirmed')>confirmed</option>
+                                <option value="canceled" @selected(($filters['status'] ?? '') == 'canceled')>canceled</option>
+                                <option value="completed" @selected(($filters['status'] ?? '') == 'completed')>completed</option>
+                                <option value="no_show" @selected(($filters['status'] ?? '') == 'no_show')>no_show</option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_date_from" class="text-sm text-gray-700 dark:text-gray-300">予約日(開始)</label>
+                            <input id="filter_date_from" type="date" name="date_from" value="{{ $filters['date_from'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="filter_date_to" class="text-sm text-gray-700 dark:text-gray-300">予約日(終了)</label>
+                            <input id="filter_date_to" type="date" name="date_to" value="{{ $filters['date_to'] ?? '' }}" class="border rounded p-2">
+                        </div>
+                        <div class="md:col-span-5">
+                            <x-primary-button type="submit">検索</x-primary-button>
+                        </div>
+                    </form>
+
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left">予約日時</th>
+                                <th class="px-4 py-2 text-left">レッスン</th>
+                                <th class="px-4 py-2 text-left">インストラクター</th>
+                                <th class="px-4 py-2 text-left">ユーザー</th>
+                                <th class="px-4 py-2 text-left">状態</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            @forelse($reservations as $r)
+                                <tr>
+                                    <td class="px-4 py-2">{{ $r->reserved_at?->format('Y-m-d H:i') ?? '-' }}</td>
+                                    <td class="px-4 py-2">{{ $r->lessonSchedule?->lesson?->name ?? '-' }}</td>
+                                    <td class="px-4 py-2">{{ $r->lessonSchedule?->lesson?->instructor?->name ?? '-' }}</td>
+                                    <td class="px-4 py-2">{{ $r->user?->name ?? '-' }} ({{ $r->user?->email ?? '' }})</td>
+                                    <td class="px-4 py-2">
+                                        @php
+                                            $badgeClass = match ($r->status) {
+                                                'pending' => 'bg-yellow-100 text-yellow-800',
+                                                'confirmed' => 'bg-green-100 text-green-800',
+                                                'canceled' => 'bg-red-100 text-red-800',
+                                                'completed' => 'bg-blue-100 text-blue-800',
+                                                'no_show' => 'bg-orange-100 text-orange-800',
+                                                default => 'bg-gray-100 text-gray-800',
+                                            };
+                                        @endphp
+                                        <span class="px-2 py-1 text-xs font-medium rounded {{ $badgeClass }}">
+                                            {{ $r->status }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="px-4 py-6 text-center text-gray-500">該当する予約がありません</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+
+                    <div class="mt-4">
+                        {{ $reservations->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-admin-layout>
+
+

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -12,7 +12,8 @@
     <x-admin.sidebar-link href="{{ route('admin.settings.edit') }}" :active="request()->routeIs('admin.settings.*')">システム設定</x-admin.sidebar-link>
 
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">ユーザー管理</div>
-    <x-admin.sidebar-link href="{{ route('admin.group-reservations.index') }}" :active="request()->routeIs('admin.group-reservations.*')">グループ予約</x-admin.sidebar-link>
+        <x-admin.sidebar-link href="{{ route('admin.group-reservations.index') }}" :active="request()->routeIs('admin.group-reservations.*')">グループ予約</x-admin.sidebar-link>
+        <x-admin.sidebar-link href="{{ route('admin.personal-reservations.index') }}" :active="request()->routeIs('admin.personal-reservations.*')">パーソナル予約</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.users.index') }}" :active="request()->routeIs('admin.users.*')">ユーザー</x-admin.sidebar-link>
 

--- a/resources/views/components/admin/sidebar.blade.php
+++ b/resources/views/components/admin/sidebar.blade.php
@@ -14,8 +14,8 @@
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">ユーザー管理</div>
         <x-admin.sidebar-link href="{{ route('admin.group-reservations.index') }}" :active="request()->routeIs('admin.group-reservations.*')">グループ予約</x-admin.sidebar-link>
         <x-admin.sidebar-link href="{{ route('admin.personal-reservations.index') }}" :active="request()->routeIs('admin.personal-reservations.*')">パーソナル予約</x-admin.sidebar-link>
-    <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
     <x-admin.sidebar-link href="{{ route('admin.users.index') }}" :active="request()->routeIs('admin.users.*')">ユーザー</x-admin.sidebar-link>
+    <x-admin.sidebar-link href="{{ route('admin.subscriptions.index') }}" :active="request()->routeIs('admin.subscriptions.*')">サブスクリプション</x-admin.sidebar-link>
 
     <div class="pt-4 text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">アカウント</div>
     <form method="POST" action="{{ route('logout') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\StoreController;
 use App\Http\Controllers\Admin\SubscriptionPlanController;
 use App\Http\Controllers\Admin\SubscriptionController as AdminUserSubscriptionController;
 use App\Http\Controllers\Admin\GroupReservationController;
+use App\Http\Controllers\Admin\PersonalReservationController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InstructorProfileController;
 use App\Http\Controllers\ProfileController;
@@ -142,6 +143,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         // Admin: group lesson reservations index
         Route::resource('group-reservations', GroupReservationController::class)->only(['index']);
+
+        // Admin: personal lesson reservations index
+        Route::resource('personal-reservations', PersonalReservationController::class)->only(['index']);
 
         // Admin: notification templates CRUD
         Route::resource('notification-templates', NotificationTemplateController::class);

--- a/tests/Feature/Admin/PersonalReservationIndexTest.php
+++ b/tests/Feature/Admin/PersonalReservationIndexTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Lesson;
+use App\Models\LessonSchedule;
+use App\Models\Reservation;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class PersonalReservationIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_access_personal_reservations_index(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'email_verified_at' => now(),
+        ]);
+        $this->actingAs($admin);
+
+        $this->get(route('admin.personal-reservations.index'))
+            ->assertOk();
+    }
+
+    public function test_non_admin_is_forbidden(): void
+    {
+        $user = User::factory()->create([
+            'role' => User::ROLE_USER,
+            'email_verified_at' => now(),
+        ]);
+        $this->actingAs($user);
+
+        $this->get(route('admin.personal-reservations.index'))
+            ->assertForbidden();
+    }
+
+    public function test_filters_behave_correctly(): void
+    {
+        $admin = User::factory()->create([
+            'role' => User::ROLE_ADMIN,
+            'email_verified_at' => now(),
+        ]);
+        $this->actingAs($admin);
+
+        Carbon::setTestNow(Carbon::create(2025, 9, 24, 9, 0, 0));
+
+        $instructorA = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor A', 'email_verified_at' => now()]);
+        $instructorB = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor B', 'email_verified_at' => now()]);
+
+        $lessonA = Lesson::factory()->forInstructor($instructorA)->create(['name' => 'Lesson A', 'capacity' => 1]);
+        $lessonB = Lesson::factory()->forInstructor($instructorB)->create(['name' => 'Lesson B', 'capacity' => 1]);
+
+        $d1 = Carbon::now()->addDays(1)->setTime(10, 0);
+        $d2 = Carbon::now()->addDays(3)->setTime(11, 0);
+
+        $scheduleA = LessonSchedule::factory()->for($lessonA)->create([
+            'start_datetime' => $d1->copy(),
+            'end_datetime' => $d1->copy()->addHour(),
+        ]);
+        $scheduleB = LessonSchedule::factory()->for($lessonB)->create([
+            'start_datetime' => $d2->copy(),
+            'end_datetime' => $d2->copy()->addHour(),
+        ]);
+
+        $user1 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Taro User', 'email' => 'taro@example.com', 'email_verified_at' => now()]);
+        $user2 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Jiro User', 'email' => 'jiro@example.com', 'email_verified_at' => now()]);
+
+        $sub1 = UserSubscription::factory()->for($user1)->active()->withRemainingLessons(5)->create();
+        $sub2 = UserSubscription::factory()->for($user2)->active()->withRemainingLessons(5)->create();
+
+        Reservation::factory()->create([
+            'user_id' => $user1->id,
+            'user_subscription_id' => $sub1->id,
+            'lesson_schedule_id' => $scheduleA->id,
+            'status' => 'pending',
+        ]);
+        Reservation::factory()->create([
+            'user_id' => $user2->id,
+            'user_subscription_id' => $sub2->id,
+            'lesson_schedule_id' => $scheduleB->id,
+            'status' => 'confirmed',
+        ]);
+
+        // No filter
+        $this->get(route('admin.personal-reservations.index'))
+            ->assertOk()
+            ->assertSee('Lesson A')
+            ->assertSee('Lesson B');
+
+        // instructor filter
+        $resp = $this->get(route('admin.personal-reservations.index', ['instructor_id' => $instructorB->id]))
+            ->assertOk()
+            ->assertSee('Lesson B');
+        $resp->assertViewHas('reservations', function ($reservations) use ($lessonB) {
+            $items = collect($reservations->items());
+            return $items->count() === 1
+                && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonB->id;
+        });
+
+        // lesson filter
+        $resp = $this->get(route('admin.personal-reservations.index', ['lesson_id' => $lessonA->id]))
+            ->assertOk()
+            ->assertSee('Lesson A');
+        $resp->assertViewHas('reservations', function ($reservations) use ($lessonA) {
+            $items = collect($reservations->items());
+            return $items->count() === 1
+                && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonA->id;
+        });
+
+        // status filter
+        $resp = $this->get(route('admin.personal-reservations.index', ['status' => 'pending']))
+            ->assertOk()
+            ->assertSee('pending');
+
+        // date_from filter (include only scheduleB)
+        $resp = $this->get(route('admin.personal-reservations.index', ['date_from' => $d2->toDateString()]))
+            ->assertOk()
+            ->assertSee('Lesson B');
+
+        // date_to filter (include only scheduleA)
+        $resp = $this->get(route('admin.personal-reservations.index', ['date_to' => $d1->toDateString()]))
+            ->assertOk()
+            ->assertSee('Lesson A');
+
+        // user term filter (by name/email)
+        $resp = $this->get(route('admin.personal-reservations.index', ['user' => 'taro']))
+            ->assertOk()
+            ->assertSee('Taro User');
+    }
+}
+
+

--- a/tests/Feature/Admin/PersonalReservationIndexTest.php
+++ b/tests/Feature/Admin/PersonalReservationIndexTest.php
@@ -49,89 +49,91 @@ class PersonalReservationIndexTest extends TestCase
 
         Carbon::setTestNow(Carbon::create(2025, 9, 24, 9, 0, 0));
 
-        $instructorA = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor A', 'email_verified_at' => now()]);
-        $instructorB = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor B', 'email_verified_at' => now()]);
+        try {
+            $instructorA = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor A', 'email_verified_at' => now()]);
+            $instructorB = User::factory()->create(['role' => User::ROLE_INSTRUCTOR, 'name' => 'Instructor B', 'email_verified_at' => now()]);
 
-        $lessonA = Lesson::factory()->forInstructor($instructorA)->create(['name' => 'Lesson A', 'capacity' => 1]);
-        $lessonB = Lesson::factory()->forInstructor($instructorB)->create(['name' => 'Lesson B', 'capacity' => 1]);
+            $lessonA = Lesson::factory()->forInstructor($instructorA)->create(['name' => 'Lesson A', 'capacity' => 1]);
+            $lessonB = Lesson::factory()->forInstructor($instructorB)->create(['name' => 'Lesson B', 'capacity' => 1]);
 
-        $d1 = Carbon::now()->addDays(1)->setTime(10, 0);
-        $d2 = Carbon::now()->addDays(3)->setTime(11, 0);
+            $d1 = Carbon::now()->addDays(1)->setTime(10, 0);
+            $d2 = Carbon::now()->addDays(3)->setTime(11, 0);
 
-        $scheduleA = LessonSchedule::factory()->for($lessonA)->create([
-            'start_datetime' => $d1->copy(),
-            'end_datetime' => $d1->copy()->addHour(),
-        ]);
-        $scheduleB = LessonSchedule::factory()->for($lessonB)->create([
-            'start_datetime' => $d2->copy(),
-            'end_datetime' => $d2->copy()->addHour(),
-        ]);
+            $scheduleA = LessonSchedule::factory()->for($lessonA)->create([
+                'start_datetime' => $d1->copy(),
+                'end_datetime' => $d1->copy()->addHour(),
+            ]);
+            $scheduleB = LessonSchedule::factory()->for($lessonB)->create([
+                'start_datetime' => $d2->copy(),
+                'end_datetime' => $d2->copy()->addHour(),
+            ]);
 
-        $user1 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Taro User', 'email' => 'taro@example.com', 'email_verified_at' => now()]);
-        $user2 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Jiro User', 'email' => 'jiro@example.com', 'email_verified_at' => now()]);
+            $user1 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Taro User', 'email' => 'taro@example.com', 'email_verified_at' => now()]);
+            $user2 = User::factory()->create(['role' => User::ROLE_USER, 'name' => 'Jiro User', 'email' => 'jiro@example.com', 'email_verified_at' => now()]);
 
-        $sub1 = UserSubscription::factory()->for($user1)->active()->withRemainingLessons(5)->create();
-        $sub2 = UserSubscription::factory()->for($user2)->active()->withRemainingLessons(5)->create();
+            $sub1 = UserSubscription::factory()->for($user1)->active()->withRemainingLessons(5)->create();
+            $sub2 = UserSubscription::factory()->for($user2)->active()->withRemainingLessons(5)->create();
 
-        Reservation::factory()->create([
-            'user_id' => $user1->id,
-            'user_subscription_id' => $sub1->id,
-            'lesson_schedule_id' => $scheduleA->id,
-            'status' => 'pending',
-        ]);
-        Reservation::factory()->create([
-            'user_id' => $user2->id,
-            'user_subscription_id' => $sub2->id,
-            'lesson_schedule_id' => $scheduleB->id,
-            'status' => 'confirmed',
-        ]);
+            Reservation::factory()->create([
+                'user_id' => $user1->id,
+                'user_subscription_id' => $sub1->id,
+                'lesson_schedule_id' => $scheduleA->id,
+                'status' => 'pending',
+            ]);
+            Reservation::factory()->create([
+                'user_id' => $user2->id,
+                'user_subscription_id' => $sub2->id,
+                'lesson_schedule_id' => $scheduleB->id,
+                'status' => 'confirmed',
+            ]);
 
-        // No filter
-        $this->get(route('admin.personal-reservations.index'))
-            ->assertOk()
-            ->assertSee('Lesson A')
-            ->assertSee('Lesson B');
+            // No filter
+            $this->get(route('admin.personal-reservations.index'))
+                ->assertOk()
+                ->assertSee('Lesson A')
+                ->assertSee('Lesson B');
 
-        // instructor filter
-        $resp = $this->get(route('admin.personal-reservations.index', ['instructor_id' => $instructorB->id]))
-            ->assertOk()
-            ->assertSee('Lesson B');
-        $resp->assertViewHas('reservations', function ($reservations) use ($lessonB) {
-            $items = collect($reservations->items());
-            return $items->count() === 1
-                && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonB->id;
-        });
+            // instructor filter
+            $resp = $this->get(route('admin.personal-reservations.index', ['instructor_id' => $instructorB->id]))
+                ->assertOk()
+                ->assertSee('Lesson B');
+            $resp->assertViewHas('reservations', function ($reservations) use ($lessonB) {
+                $items = collect($reservations->items());
+                return $items->count() === 1
+                    && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonB->id;
+            });
 
-        // lesson filter
-        $resp = $this->get(route('admin.personal-reservations.index', ['lesson_id' => $lessonA->id]))
-            ->assertOk()
-            ->assertSee('Lesson A');
-        $resp->assertViewHas('reservations', function ($reservations) use ($lessonA) {
-            $items = collect($reservations->items());
-            return $items->count() === 1
-                && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonA->id;
-        });
+            // lesson filter
+            $resp = $this->get(route('admin.personal-reservations.index', ['lesson_id' => $lessonA->id]))
+                ->assertOk()
+                ->assertSee('Lesson A');
+            $resp->assertViewHas('reservations', function ($reservations) use ($lessonA) {
+                $items = collect($reservations->items());
+                return $items->count() === 1
+                    && optional(optional($items->first()->lessonSchedule)->lesson)->id === $lessonA->id;
+            });
 
-        // status filter
-        $resp = $this->get(route('admin.personal-reservations.index', ['status' => 'pending']))
-            ->assertOk()
-            ->assertSee('pending');
+            // status filter
+            $resp = $this->get(route('admin.personal-reservations.index', ['status' => 'pending']))
+                ->assertOk()
+                ->assertSee('pending');
 
-        // date_from filter (include only scheduleB)
-        $resp = $this->get(route('admin.personal-reservations.index', ['date_from' => $d2->toDateString()]))
-            ->assertOk()
-            ->assertSee('Lesson B');
+            // date_from filter (include only scheduleB)
+            $resp = $this->get(route('admin.personal-reservations.index', ['date_from' => $d2->toDateString()]))
+                ->assertOk()
+                ->assertSee('Lesson B');
 
-        // date_to filter (include only scheduleA)
-        $resp = $this->get(route('admin.personal-reservations.index', ['date_to' => $d1->toDateString()]))
-            ->assertOk()
-            ->assertSee('Lesson A');
+            // date_to filter (include only scheduleA)
+            $resp = $this->get(route('admin.personal-reservations.index', ['date_to' => $d1->toDateString()]))
+                ->assertOk()
+                ->assertSee('Lesson A');
 
-        // user term filter (by name/email)
-        $resp = $this->get(route('admin.personal-reservations.index', ['user' => 'taro']))
-            ->assertOk()
-            ->assertSee('Taro User');
+            // user term filter (by name/email)
+            $resp = $this->get(route('admin.personal-reservations.index', ['user' => 'taro']))
+                ->assertOk()
+                ->assertSee('Taro User');
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 }
-
-


### PR DESCRIPTION
- Admin\PersonalReservationController@indexを実装（フィルタ・ソート機能付き）
- IndexPersonalReservationsRequestで入力前処理・バリデーションを追加
- admin/personal-reservations/index.blade.phpを作成（グループ予約UIと統一）
- 管理画面サイドバーにパーソナル予約リンクを追加
- PersonalReservationIndexTestでフィルタ動作とアクセス制御をテスト
- 容量=1のレッスンでパーソナル予約をフィルタリング
- Carbon::setTestNowでテスト時刻を固定して境界不安定を解消

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 管理画面に「パーソナル予約」一覧を追加。講師・レッスン・ユーザー・状態・日付範囲で絞り込み可能、最新スケジュール順で表示、ステータスバッジとページネーションあり。サイドバーにメニューを追加。
- **セキュリティ / アクセス**
  - 管理者のみアクセス可能に制限。
- **テスト**
  - アクセス制御と各種フィルタの挙動を検証する機能テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->