### PR TITLE
feat(store-favorites): ストアお気に入り機能を実装

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -510,7 +510,7 @@
 ### User Interface Development Tasks
 ### ユーザーインターフェース開発タスク
 
-- [ ] 42. Create user top page / ユーザートップページを作成
+- [x] 42. Create user top page / ユーザートップページを作成
   - File: resources/views/home.blade.php (modify) / ファイル: resources/views/home.blade.php (修正)
   - File: app/Http/Controllers/HomeController.php (new) / ファイル: app/Http/Controllers/HomeController.php (新規)
   - Display reservation status overview / 予約状況の概要を表示
@@ -529,7 +529,7 @@
   - Dependencies: None / 依存関係: なし
   - Estimated time: 10 minutes / 推定時間: 10分
 
-- [ ] 44. Create store listing and detail pages / 店舗一覧・詳細ページを作成
+- [x] 44. Create store listing and detail pages / 店舗一覧・詳細ページを作成
   - File: resources/views/stores/index.blade.php (new) / ファイル: resources/views/stores/index.blade.php (新規)
   - File: resources/views/stores/show.blade.php (new) / ファイル: resources/views/stores/show.blade.php (新規)
   - File: app/Http/Controllers/StoreController.php (new) / ファイル: app/Http/Controllers/StoreController.php (新規)

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Store;
+use App\Models\UserFavorite;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class FavoriteController extends Controller
+{
+    /**
+     * Toggle favorite for a store for the authenticated user.
+     */
+    public function toggleStore(Request $request, Store $store): RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($store->is_active, 404);
+
+        $favorite = UserFavorite::query()
+            ->where('user_id', $user->id)
+            ->where('favoritable_type', Store::class)
+            ->where('favoritable_id', $store->id)
+            ->first();
+
+        if ($favorite) {
+            $favorite->delete();
+        } else {
+            UserFavorite::create([
+                'user_id' => $user->id,
+                'favoritable_type' => Store::class,
+                'favoritable_id' => $store->id,
+            ]);
+        }
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -6,6 +6,7 @@ use App\Models\Store;
 use App\Models\UserFavorite;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class FavoriteController extends Controller
 {
@@ -16,21 +17,23 @@ class FavoriteController extends Controller
     {
         $user = $request->user();
 
-        abort_unless($store->is_active, 404);
+        if (! $store->is_active) {
+            abort(404, 'Store not found or inactive');
+        }
 
-        $favorite = UserFavorite::query()
-            ->where('user_id', $user->id)
-            ->where('favoritable_type', Store::class)
-            ->where('favoritable_id', $store->id)
-            ->first();
+        // Atomic toggle to avoid race: try delete first; if nothing deleted, insert (ignore on unique conflict)
+        $criteria = [
+            'user_id' => $user->id,
+            'favoritable_type' => Store::class,
+            'favoritable_id' => $store->id,
+        ];
 
-        if ($favorite) {
-            $favorite->delete();
-        } else {
-            UserFavorite::create([
-                'user_id' => $user->id,
-                'favoritable_type' => Store::class,
-                'favoritable_id' => $store->id,
+        $deleted = UserFavorite::query()->where($criteria)->delete();
+
+        if ($deleted === 0) {
+            DB::table('user_favorites')->insertOrIgnore($criteria + [
+                'created_at' => now(),
+                'updated_at' => now(),
             ]);
         }
 

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -16,13 +16,14 @@ class StoreController extends Controller
         $stores = Store::query()
             ->where('is_active', true)
             ->orderBy('name')
-            ->paginate(12);
+            ->paginate(config('pagination.stores', 12));
 
         // preload favorite store ids for current user
         $favoriteStoreIds = $user
             ? $user->favorites()
-                ->where('favoritable_type', Store::class)
+                ->stores()
                 ->pluck('favoritable_id')
+                ->map(fn ($id) => (int) $id)
                 ->all()
             : [];
 
@@ -32,7 +33,7 @@ class StoreController extends Controller
         ]);
     }
 
-    public function show(Store $store, Request $request): View
+    public function show(Store $store): View
     {
         abort_unless($store->is_active, 404);
 
@@ -50,7 +51,7 @@ class StoreController extends Controller
             ->whereHas('lesson', fn ($q) => $q->where('store_id', $store->id))
             ->where('start_datetime', '>=', now())
             ->orderBy('start_datetime')
-            ->limit(10)
+            ->limit(config('pagination.upcoming_schedules', 10))
             ->get();
 
         return view('stores.show', compact('store', 'upcomingSchedules', 'mapUrl'));

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LessonSchedule;
+use App\Models\Store;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class StoreController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+
+        $stores = Store::query()
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->paginate(12);
+
+        // preload favorite store ids for current user
+        $favoriteStoreIds = $user
+            ? $user->favorites()
+                ->where('favoritable_type', Store::class)
+                ->pluck('favoritable_id')
+                ->all()
+            : [];
+
+        return view('stores.index', [
+            'stores' => $stores,
+            'favoriteStoreIds' => $favoriteStoreIds,
+        ]);
+    }
+
+    public function show(Store $store, Request $request): View
+    {
+        abort_unless($store->is_active, 404);
+
+        // Normalize Google Map URL to safe scheme or null
+        $mapUrl = null;
+        if (! empty($store->google_map_url)) {
+            $trimmed = trim((string) $store->google_map_url);
+            if (str_starts_with($trimmed, 'https://')) {
+                $mapUrl = $trimmed;
+            }
+        }
+
+        $upcomingSchedules = LessonSchedule::query()
+            ->with(['lesson.instructor'])
+            ->whereHas('lesson', fn ($q) => $q->where('store_id', $store->id))
+            ->where('start_datetime', '>=', now())
+            ->orderBy('start_datetime')
+            ->limit(10)
+            ->get();
+
+        return view('stores.show', compact('store', 'upcomingSchedules', 'mapUrl'));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
+
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Cashier\Billable;
@@ -105,9 +105,9 @@ class User extends Authenticatable implements MustVerifyEmail
     /**
      * Get the favorites for this user.
      */
-    public function favorites(): MorphMany
+    public function favorites(): HasMany
     {
-        return $this->morphMany(UserFavorite::class, 'user');
+        return $this->hasMany(UserFavorite::class);
     }
 
     /**

--- a/config/pagination.php
+++ b/config/pagination.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    // Stores index per-page
+    'stores' => 12,
+
+    // Store detail upcoming schedules limit
+    'upcoming_schedules' => 10,
+];

--- a/resources/views/layouts/user-footer.blade.php
+++ b/resources/views/layouts/user-footer.blade.php
@@ -1,32 +1,62 @@
 <div class="fixed bottom-0 left-0 right-0 z-40 bg-white dark:bg-gray-800/90 backdrop-blur-sm border-t border-gray-200 dark:border-gray-700 max-w-7xl mx-auto">
     <div class="px-4 py-2 pb-[calc(env(safe-area-inset-bottom))]">
         <div class="flex justify-around items-center">
-            <a href="#" class="flex flex-col items-center space-y-0.5 text-blue-600 dark:text-blue-400 p-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+            <!-- ホーム -->
+            <a href="{{ route('home') }}" class="flex flex-col items-center space-y-0.5 text-blue-600 dark:text-blue-400 p-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
                 </svg>
-                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">予約</span>
+                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">ホーム</span>
             </a>
 
-            <a href="#" class="flex flex-col items-center space-y-0.5 text-gray-500 dark:text-gray-400 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <!-- 店舗一覧 -->
+            <a href="{{ route('stores.index') }}" class="flex flex-col items-center space-y-0.5 text-gray-600 dark:text-gray-300 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M5 7v10a2 2 0 002 2h10a2 2 0 002-2V7m-9 4h4"/>
                 </svg>
-                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">スケジュール</span>
+                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">店舗一覧</span>
             </a>
 
-            <a href="#" class="flex flex-col items-center space-y-0.5 text-gray-500 dark:text-gray-400 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
-                </svg>
-                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">メッセージ</span>
-            </a>
+            <!-- インストラクター一覧（未実装なら無効） -->
+            @if(Route::has('instructors.index'))
+                <a href="{{ route('instructors.index') }}" class="flex flex-col items-center space-y-0.5 text-gray-600 dark:text-gray-300 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                    </svg>
+                    <span class="text-[11px] font-medium leading-4 whitespace-nowrap">インストラクター</span>
+                </a>
+            @else
+                <a aria-disabled="true" class="flex flex-col items-center space-y-0.5 text-gray-400 dark:text-gray-500 p-1.5 rounded-lg pointer-events-none opacity-60">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                    </svg>
+                    <span class="text-[11px] font-medium leading-4 whitespace-nowrap">インストラクター</span>
+                </a>
+            @endif
 
-            <a href="#" class="flex flex-col items-center space-y-0.5 text-gray-500 dark:text-gray-400 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+            <!-- プラン一覧（未実装なら無効） -->
+            @if(Route::has('plans.index'))
+                <a href="{{ route('plans.index') }}" class="flex flex-col items-center space-y-0.5 text-gray-600 dark:text-gray-300 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2-1.343-2-3-2z"/>
+                    </svg>
+                    <span class="text-[11px] font-medium leading-4 whitespace-nowrap">プラン一覧</span>
+                </a>
+            @else
+                <a aria-disabled="true" class="flex flex-col items-center space-y-0.5 text-gray-400 dark:text-gray-500 p-1.5 rounded-lg pointer-events-none opacity-60">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2-1.343-2-3-2z"/>
+                    </svg>
+                    <span class="text-[11px] font-medium leading-4 whitespace-nowrap">プラン一覧</span>
+                </a>
+            @endif
+
+            <!-- マイページ -->
+            <a href="{{ route('profile.edit') }}" class="flex flex-col items-center space-y-0.5 text-gray-600 dark:text-gray-300 p-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
                 </svg>
-                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">その他</span>
+                <span class="text-[11px] font-medium leading-4 whitespace-nowrap">マイページ</span>
             </a>
         </div>
     </div>

--- a/resources/views/stores/_favorite-toggle.blade.php
+++ b/resources/views/stores/_favorite-toggle.blade.php
@@ -1,0 +1,9 @@
+@php $isFav = in_array($store->id, $favoriteStoreIds ?? [], true); @endphp
+<form method="POST" action="{{ route('stores.favorite.toggle', $store) }}" class="inline-block">
+    @csrf
+    <button type="submit" aria-label="お気に入りに{{ $isFav ? '解除' : '追加' }}" class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition">
+        <svg class="w-5 h-5 {{ $isFav ? 'fill-pink-500' : 'fill-gray-400 dark:fill-gray-500' }}" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.09 5.01 12.76 4 14.5 4 17 4 19 6 19 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+        </svg>
+    </button>
+</form>

--- a/resources/views/stores/index.blade.php
+++ b/resources/views/stores/index.blade.php
@@ -1,0 +1,54 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            店舗一覧
+        </h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        @if($stores->count() === 0)
+            <p class="text-sm text-gray-600 dark:text-gray-400">公開中の店舗はありません。</p>
+        @else
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                @foreach($stores as $store)
+                    <div class="rounded-xl bg-white dark:bg-gray-800 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)] hover:shadow-md transition">
+                        <a href="{{ route('stores.show', $store) }}" class="block">
+                            <h3 class="font-semibold text-gray-900 dark:text-gray-100">{{ $store->name }}</h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ $store->address }}</p>
+                        </a>
+                        @if($store->phone)
+                            <div class="flex items-center justify-between mt-1">
+                                <p class="text-sm text-gray-600 dark:text-gray-400">TEL: {{ $store->phone }}</p>
+                                <form method="POST" action="{{ route('stores.favorite.toggle', $store) }}" class="inline-block">
+                                    @csrf
+                                    @php $isFav = in_array($store->id, $favoriteStoreIds ?? [], true); @endphp
+                                    <button type="submit" aria-label="お気に入りに{{ $isFav ? '解除' : '追加' }}" class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition">
+                                        <svg class="w-5 h-5 {{ $isFav ? 'fill-pink-500' : 'fill-gray-400 dark:fill-gray-500' }}" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.09 5.01 12.76 4 14.5 4 17 4 19 6 19 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+                                        </svg>
+                                    </button>
+                                </form>
+                            </div>
+                        @else
+                            <div class="flex items-center justify-end mt-1">
+                                <form method="POST" action="{{ route('stores.favorite.toggle', $store) }}" class="inline-block">
+                                    @csrf
+                                    @php $isFav = in_array($store->id, $favoriteStoreIds ?? [], true); @endphp
+                                    <button type="submit" aria-label="お気に入りに{{ $isFav ? '解除' : '追加' }}" class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition">
+                                        <svg class="w-5 h-5 {{ $isFav ? 'fill-pink-500' : 'fill-gray-400 dark:fill-gray-500' }}" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.09 5.01 12.76 4 14.5 4 17 4 19 6 19 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+                                        </svg>
+                                    </button>
+                                </form>
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="mt-6">
+                {{ $stores->links() }}
+            </div>
+        @endif
+    </div>
+</x-app-layout>

--- a/resources/views/stores/index.blade.php
+++ b/resources/views/stores/index.blade.php
@@ -19,27 +19,11 @@
                         @if($store->phone)
                             <div class="flex items-center justify-between mt-1">
                                 <p class="text-sm text-gray-600 dark:text-gray-400">TEL: {{ $store->phone }}</p>
-                                <form method="POST" action="{{ route('stores.favorite.toggle', $store) }}" class="inline-block">
-                                    @csrf
-                                    @php $isFav = in_array($store->id, $favoriteStoreIds ?? [], true); @endphp
-                                    <button type="submit" aria-label="お気に入りに{{ $isFav ? '解除' : '追加' }}" class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition">
-                                        <svg class="w-5 h-5 {{ $isFav ? 'fill-pink-500' : 'fill-gray-400 dark:fill-gray-500' }}" viewBox="0 0 24 24" aria-hidden="true">
-                                            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.09 5.01 12.76 4 14.5 4 17 4 19 6 19 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                                        </svg>
-                                    </button>
-                                </form>
+                                @include('stores._favorite-toggle', ['store' => $store, 'favoriteStoreIds' => $favoriteStoreIds])
                             </div>
                         @else
                             <div class="flex items-center justify-end mt-1">
-                                <form method="POST" action="{{ route('stores.favorite.toggle', $store) }}" class="inline-block">
-                                    @csrf
-                                    @php $isFav = in_array($store->id, $favoriteStoreIds ?? [], true); @endphp
-                                    <button type="submit" aria-label="お気に入りに{{ $isFav ? '解除' : '追加' }}" class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition">
-                                        <svg class="w-5 h-5 {{ $isFav ? 'fill-pink-500' : 'fill-gray-400 dark:fill-gray-500' }}" viewBox="0 0 24 24" aria-hidden="true">
-                                            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.09 5.01 12.76 4 14.5 4 17 4 19 6 19 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                                        </svg>
-                                    </button>
-                                </form>
+                                @include('stores._favorite-toggle', ['store' => $store, 'favoriteStoreIds' => $favoriteStoreIds])
                             </div>
                         @endif
                     </div>

--- a/resources/views/stores/show.blade.php
+++ b/resources/views/stores/show.blade.php
@@ -1,0 +1,65 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ $store->name }}
+        </h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <dt class="text-sm text-gray-500 dark:text-gray-400">住所</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $store->address }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-gray-500 dark:text-gray-400">電話番号</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $store->phone }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-gray-500 dark:text-gray-400">アクセス情報</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $store->access_info }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-gray-500 dark:text-gray-400">駐車場情報</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $store->parking_info }}</dd>
+                </div>
+                @if(!empty($mapUrl))
+                    <div class="sm:col-span-2">
+                        <dt class="text-sm text-gray-500 dark:text-gray-400">地図</dt>
+                        <dd class="mt-1">
+                            <a href="{{ $mapUrl }}" target="_blank" rel="noopener noreferrer" class="text-indigo-600 dark:text-indigo-400 hover:underline">Googleマップで開く</a>
+                        </dd>
+                    </div>
+                @endif
+                @if($store->notes)
+                    <div class="sm:col-span-2">
+                        <dt class="text-sm text-gray-500 dark:text-gray-400">備考</dt>
+                        <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $store->notes }}</dd>
+                    </div>
+                @endif
+            </dl>
+        </div>
+
+        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">この店舗の今後のレッスン</h3>
+            @if($upcomingSchedules->isEmpty())
+                <p class="text-sm text-gray-600 dark:text-gray-400">近日開催予定のレッスンはありません。</p>
+            @else
+                <ul class="space-y-3">
+                    @foreach($upcomingSchedules as $schedule)
+                        <li class="flex items-center justify-between">
+                            <div>
+                                <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $schedule->lesson?->name ?? '未設定' }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">講師: {{ $schedule->lesson?->instructor?->name ?? '未設定' }}</p>
+                            </div>
+                            <time datetime="{{ $schedule->start_datetime?->toIso8601String() }}" class="text-sm text-gray-700 dark:text-gray-300">
+                                {{ $schedule->start_datetime?->format('n月j日 H:i') }}
+                            </time>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,13 +8,15 @@ use App\Http\Controllers\Admin\NotificationTemplateController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\ReservationController as AdminReservationController;
 use App\Http\Controllers\Admin\SettingController;
-use App\Http\Controllers\Admin\StoreController;
+use App\Http\Controllers\Admin\StoreController as AdminStoreController;
 use App\Http\Controllers\Admin\SubscriptionPlanController;
 use App\Http\Controllers\Admin\SubscriptionController as AdminUserSubscriptionController;
 use App\Http\Controllers\Admin\GroupReservationController;
 use App\Http\Controllers\Admin\PersonalReservationController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\StoreController;
 use App\Http\Controllers\InstructorProfileController;
+use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\SubscriptionController;
@@ -22,6 +24,13 @@ use App\Models\LessonSchedule;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [HomeController::class, 'index'])->middleware(['auth', 'verified'])->name('home');
+
+// Stores (user-facing)
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/stores', [StoreController::class, 'index'])->name('stores.index');
+    Route::get('/stores/{store}', [StoreController::class, 'show'])->name('stores.show');
+    Route::post('/stores/{store}/favorite/toggle', [FavoriteController::class, 'toggleStore'])->name('stores.favorite.toggle');
+});
 
 Route::get('/dashboard', function () {
     $adminStats = null;
@@ -117,7 +126,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Admin: stores CRUD
     Route::prefix('admin')->as('admin.')->middleware('can:access-admin')->group(function () {
-        Route::resource('stores', StoreController::class);
+        Route::resource('stores', AdminStoreController::class);
 
         // Admin: lesson categories CRUD
         Route::resource('lesson-categories', LessonCategoryController::class);

--- a/tests/Feature/FavoriteStoreToggleTest.php
+++ b/tests/Feature/FavoriteStoreToggleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Store;
+use App\Models\User;
+use App\Models\UserFavorite;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoriteStoreToggleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_toggle_favorite(): void
+    {
+        $store = Store::factory()->create();
+        $this->post(route('stores.favorite.toggle', $store))->assertRedirect('/login');
+    }
+
+    public function test_user_can_favorite_and_unfavorite_store(): void
+    {
+        $user = User::factory()->create();
+        $store = Store::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('stores.favorite.toggle', $store))
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('user_favorites', [
+            'user_id' => $user->id,
+            'favoritable_type' => Store::class,
+            'favoritable_id' => $store->id,
+        ]);
+
+        // Toggle again to unfavorite
+        $this->actingAs($user)
+            ->post(route('stores.favorite.toggle', $store))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('user_favorites', [
+            'user_id' => $user->id,
+            'favoritable_type' => Store::class,
+            'favoritable_id' => $store->id,
+        ]);
+    }
+
+    public function test_inactive_store_returns_404(): void
+    {
+        $user = User::factory()->create();
+        $store = Store::factory()->state(['is_active' => false])->create();
+
+        $this->actingAs($user)
+            ->post(route('stores.favorite.toggle', $store))
+            ->assertNotFound();
+    }
+
+    public function test_concurrent_insert_does_not_duplicate(): void
+    {
+        $user = User::factory()->create();
+        $store = Store::factory()->create();
+
+        // Simulate two quick successive calls
+        $this->actingAs($user)
+            ->post(route('stores.favorite.toggle', $store));
+        $this->actingAs($user)
+            ->post(route('stores.favorite.toggle', $store));
+
+        // Because toggle may unfavorite on second call, ensure max one record at any time
+        $count = UserFavorite::query()
+            ->where('user_id', $user->id)
+            ->where('favoritable_type', Store::class)
+            ->where('favoritable_id', $store->id)
+            ->count();
+
+        $this->assertTrue(in_array($count, [0, 1], true));
+    }
+}


### PR DESCRIPTION
- FavoriteController の追加と toggleStore アクション実装

- ルート追加: POST /stores/{store}/favorite/toggle

- stores/index.blade.php にハートアイコンを追加、favoriteStoreIds で色を切替

- StoreController@index でユーザーのお気に入り店舗IDをプリロードしてビューへ渡す

- User モデルの favorites リレーションを HasMany に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ユーザートップ（ホーム）ページを追加。予約状況、今後の予約、サブスク状況、予約ページへのクイックアクセスを表示。
  - 店舗一覧・店舗詳細ページを追加。住所・アクセス・駐車場情報、地図リンク、注意事項、店舗別の直近レッスンを確認可能。
  - 店舗のお気に入り登録/解除をトグル操作で対応。一覧から状態が分かりやすく表示。
- UI
  - フッターナビを更新（ホーム、店舗一覧、インストラクター、プラン、マイページ）。未提供の項目は無効表示でアクセシビリティに配慮。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->