### PR TITLE
feat(instructors): インストラクター一覧・詳細を実装

### DIFF
--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -541,7 +541,7 @@
   - Dependencies: Task 43 / 依存関係: タスク43
   - Estimated time: 40 minutes / 推定時間: 40分
 
-- [ ] 45. Create instructor listing and detail pages / インストラクター一覧・詳細ページを作成
+- [x] 45. Create instructor listing and detail pages / インストラクター一覧・詳細ページを作成
   - File: resources/views/instructors/index.blade.php (new) / ファイル: resources/views/instructors/index.blade.php (新規)
   - File: resources/views/instructors/show.blade.php (new) / ファイル: resources/views/instructors/show.blade.php (新規)
   - File: app/Http/Controllers/InstructorController.php (new) / ファイル: app/Http/Controllers/InstructorController.php (新規)

--- a/app/Http/Controllers/InstructorController.php
+++ b/app/Http/Controllers/InstructorController.php
@@ -12,6 +12,7 @@ class InstructorController extends Controller
     {
         $instructors = User::query()
             ->where('role', User::ROLE_INSTRUCTOR)
+            ->with('instructorProfile')
             ->orderBy('name')
             ->paginate(config('pagination.instructors', 12));
 

--- a/app/Http/Controllers/InstructorController.php
+++ b/app/Http/Controllers/InstructorController.php
@@ -4,12 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Models\LessonSchedule;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class InstructorController extends Controller
 {
-    public function index(Request $request): View
+    public function index(): View
     {
         $instructors = User::query()
             ->where('role', User::ROLE_INSTRUCTOR)

--- a/app/Http/Controllers/InstructorController.php
+++ b/app/Http/Controllers/InstructorController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LessonSchedule;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class InstructorController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $instructors = User::query()
+            ->where('role', User::ROLE_INSTRUCTOR)
+            ->orderBy('name')
+            ->paginate(config('pagination.instructors', 12));
+
+        return view('instructors.index', compact('instructors'));
+    }
+
+    public function show(User $instructor): View
+    {
+        abort_unless($instructor->role === User::ROLE_INSTRUCTOR, 404);
+
+        $upcomingSchedules = LessonSchedule::query()
+            ->with(['lesson.store'])
+            ->whereHas('lesson', fn ($q) => $q->where('instructor_user_id', $instructor->id))
+            ->where('start_datetime', '>=', now())
+            ->orderBy('start_datetime')
+            ->limit(config('pagination.instructor_upcoming_schedules', 10))
+            ->get();
+
+        return view('instructors.show', compact('instructor', 'upcomingSchedules'));
+    }
+}

--- a/app/Http/Controllers/InstructorController.php
+++ b/app/Http/Controllers/InstructorController.php
@@ -23,6 +23,9 @@ class InstructorController extends Controller
     {
         abort_unless($instructor->role === User::ROLE_INSTRUCTOR, 404);
 
+        // Eager load profile to avoid additional queries in the view
+        $instructor->load('instructorProfile');
+
         $upcomingSchedules = LessonSchedule::query()
             ->with(['lesson.store'])
             ->whereHas('lesson', fn ($q) => $q->where('instructor_user_id', $instructor->id))

--- a/config/pagination.php
+++ b/config/pagination.php
@@ -6,4 +6,10 @@ return [
 
     // Store detail upcoming schedules limit
     'upcoming_schedules' => 10,
+
+    // Instructors index per-page
+    'instructors' => 12,
+
+    // Instructor detail upcoming schedules limit
+    'instructor_upcoming_schedules' => 10,
 ];

--- a/resources/views/instructors/index.blade.php
+++ b/resources/views/instructors/index.blade.php
@@ -1,0 +1,28 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            インストラクター一覧
+        </h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        @if($instructors->count() === 0)
+            <p class="text-sm text-gray-600 dark:text-gray-400">公開中のインストラクターはいません。</p>
+        @else
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                @foreach($instructors as $instructor)
+                    <a href="{{ route('instructors.show', $instructor) }}" class="block rounded-xl bg-white dark:bg-gray-800 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)] hover:shadow-md transition">
+                        <h3 class="font-semibold text-gray-900 dark:text-gray-100">{{ $instructor->name }}</h3>
+                        @if(optional($instructor->instructorProfile)->bio)
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{{ optional($instructor->instructorProfile)->bio }}</p>
+                        @endif
+                    </a>
+                @endforeach
+            </div>
+
+            <div class="mt-6">
+                {{ $instructors->links() }}
+            </div>
+        @endif
+    </div>
+</x-app-layout>

--- a/resources/views/instructors/index.blade.php
+++ b/resources/views/instructors/index.blade.php
@@ -6,15 +6,15 @@
     </x-slot>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        @if($instructors->count() === 0)
+        @if($instructors->isEmpty())
             <p class="text-sm text-gray-600 dark:text-gray-400">公開中のインストラクターはいません。</p>
         @else
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 @foreach($instructors as $instructor)
                     <a href="{{ route('instructors.show', $instructor) }}" class="block rounded-xl bg-white dark:bg-gray-800 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)] hover:shadow-md transition">
                         <h3 class="font-semibold text-gray-900 dark:text-gray-100">{{ $instructor->name }}</h3>
-                        @if(optional($instructor->instructorProfile)->bio)
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{{ optional($instructor->instructorProfile)->bio }}</p>
+                        @if($instructor->instructorProfile?->bio)
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">{{ $instructor->instructorProfile->bio }}</p>
                         @endif
                     </a>
                 @endforeach

--- a/resources/views/instructors/show.blade.php
+++ b/resources/views/instructors/show.blade.php
@@ -1,0 +1,47 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ $instructor->name }}
+        </h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">プロフィール</h3>
+            <div class="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+                @if(optional($instructor->instructorProfile)->bio)
+                    <p>{{ $instructor->instructorProfile->bio }}</p>
+                @else
+                    <p>プロフィール情報は未設定です。</p>
+                @endif
+                @if(optional($instructor->instructorProfile)->qualifications)
+                    <div>
+                        <h4 class="font-medium text-gray-900 dark:text-gray-100">資格・経歴</h4>
+                        <p class="mt-1">{{ $instructor->instructorProfile->qualifications }}</p>
+                    </div>
+                @endif
+            </div>
+        </div>
+
+        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">今後のスケジュール</h3>
+            @if($upcomingSchedules->isEmpty())
+                <p class="text-sm text-gray-600 dark:text-gray-400">近日開催予定のレッスンはありません。</p>
+            @else
+                <ul class="space-y-3">
+                    @foreach($upcomingSchedules as $schedule)
+                        <li class="flex items-center justify-between">
+                            <div>
+                                <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $schedule->lesson?->name ?? '未設定' }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">店舗: {{ $schedule->lesson?->store?->name ?? '未設定' }}</p>
+                            </div>
+                            <time datetime="{{ $schedule->start_datetime?->toIso8601String() }}" class="text-sm text-gray-700 dark:text-gray-300">
+                                {{ $schedule->start_datetime?->format('n月j日 H:i') }}
+                            </time>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/instructors/show.blade.php
+++ b/resources/views/instructors/show.blade.php
@@ -35,8 +35,8 @@
                                 <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $schedule->lesson?->name ?? '未設定' }}</p>
                                 <p class="text-sm text-gray-600 dark:text-gray-400">店舗: {{ $schedule->lesson?->store?->name ?? '未設定' }}</p>
                             </div>
-                            <time datetime="{{ $schedule->start_datetime?->toIso8601String() }}" class="text-sm text-gray-700 dark:text-gray-300">
-                                {{ $schedule->start_datetime?->format('n月j日 H:i') }}
+                            <time datetime="{{ $schedule->start_datetime?->toIso8601String() ?? '' }}" class="text-sm text-gray-700 dark:text-gray-300">
+                                {{ $schedule->start_datetime?->format('n月j日 H:i') ?? '未設定' }}
                             </time>
                         </li>
                     @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Admin\PersonalReservationController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\StoreController;
 use App\Http\Controllers\InstructorProfileController;
+use App\Http\Controllers\InstructorController as PublicInstructorController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReservationController;
@@ -30,6 +31,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/stores', [StoreController::class, 'index'])->name('stores.index');
     Route::get('/stores/{store}', [StoreController::class, 'show'])->name('stores.show');
     Route::post('/stores/{store}/favorite/toggle', [FavoriteController::class, 'toggleStore'])->name('stores.favorite.toggle');
+
+    // Instructors (user-facing)
+    Route::get('/instructors', [PublicInstructorController::class, 'index'])->name('instructors.index');
+    Route::get('/instructors/{instructor}', [PublicInstructorController::class, 'show'])->name('instructors.show');
 });
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
- InstructorController を追加（index/show）

- ルート追加: GET /instructors, GET /instructors/{instructor}

- ビュー追加: instructors/index.blade.php, instructors/show.blade.php

- ページネーション設定を追加・適用

- null安全・フォールバックを調整

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - インストラクター一覧ページを追加（カード表示、ダーク/ライト対応、詳細ページへのリンク、12件/ページでページネーション）。
  - インストラクター詳細ページを追加。プロフィール（自己紹介・資格表示）と今後のレッスンを最大10件表示（レッスン名・店舗名・開始日時、未設定時のプレースホルダ含む）。
  - 公開ルートを追加し、一覧・詳細ページへアクセス可能に。
- ドキュメント
  - 対応タスクを完了済みに更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->