### PR TITLE
fix(stripe): Webhookのサブスク同期をupdateOrCreateで一意制約違反回避

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -64,6 +64,18 @@ jobs:
           echo "STRIPE_SECRET=sk_test_dummy_secret_for_ci" >> .env.testing
           echo "STRIPE_WEBHOOK_SECRET=whsec_dummy_webhook_secret_for_ci" >> .env.testing
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build Vite assets
+        run: npm run build
+
       - name: Create SQLite database
         run: |
           mkdir -p database

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Run migrations
         run: php artisan migrate --env=testing --force
 
-      - name: Execute PHPUnit tests with coverage
-        run: vendor/bin/phpunit --coverage-clover coverage.xml
+      - name: Execute tests with coverage
+        run: vendor/bin/pest --coverage --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,91 @@
+name: PHPUnit Tests
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4']
+
+    name: PHP ${{ matrix.php }} Tests
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP (with coverage)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, fileinfo
+          coverage: xdebug
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Create .env.testing file
+        run: |
+          cp .env.example .env.testing
+          echo "APP_KEY=" >> .env.testing
+          echo "DB_CONNECTION=sqlite" >> .env.testing
+          echo "DB_DATABASE=./database/database.sqlite" >> .env.testing
+
+      - name: Generate application key
+        run: php artisan key:generate --env=testing
+
+      - name: Set Stripe test keys (for testing)
+        run: |
+          echo "STRIPE_KEY=pk_test_dummy_key_for_ci" >> .env.testing
+          echo "STRIPE_SECRET=sk_test_dummy_secret_for_ci" >> .env.testing
+          echo "STRIPE_WEBHOOK_SECRET=whsec_dummy_webhook_secret_for_ci" >> .env.testing
+
+      - name: Create SQLite database
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+
+      - name: Run migrations
+        run: php artisan migrate --env=testing --force
+
+      - name: Execute PHPUnit tests with coverage
+        run: vendor/bin/phpunit --coverage-clover coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+      - name: Upload test results (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-php-${{ matrix.php }}
+          path: |
+            storage/logs/
+            tests/

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Create .env.testing file
         run: |
           cp .env.example .env.testing
-          echo "APP_KEY=" >> .env.testing
           echo "DB_CONNECTION=sqlite" >> .env.testing
           echo "DB_DATABASE=./database/database.sqlite" >> .env.testing
 

--- a/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
+++ b/.spec-workflow/specs/yoga-pilates-reservation-system/tasks.md
@@ -577,7 +577,7 @@
   - Dependencies: Task 46 / 依存関係: タスク46
   - Estimated time: 35 minutes / 推定時間: 35分
 
-- [ ] 48. Create subscription management page / サブスクリプション管理ページを作成
+- [x] 48. Create subscription management page / サブスクリプション管理ページを作成
   - File: resources/views/subscriptions/manage.blade.php (new) / ファイル: resources/views/subscriptions/manage.blade.php (新規)
   - File: app/Http/Controllers/Subscription/ManageController.php (new) / ファイル: app/Http/Controllers/Subscription/ManageController.php (新規)
   - Display current plan status and details / 現在のプラン状況・詳細を表示

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -16,7 +16,7 @@ class HomeController extends Controller
     {
         $user = $request->user();
 
-        // Get next reservations (start time from now, soonest first), confirmed, limit 2
+        // Get next reservations (start time from now, soonest first), confirmed, limit 3
         $currentReservations = Reservation::query()
             ->select('reservations.*')
             ->join('lesson_schedules', 'lesson_schedules.id', '=', 'reservations.lesson_schedule_id')
@@ -29,17 +29,18 @@ class HomeController extends Controller
             ->confirmed()
             ->where('lesson_schedules.start_datetime', '>=', now())
             ->orderBy('lesson_schedules.start_datetime', 'asc')
-            ->limit(2)
+            ->limit(3)
             ->get();
 
-        // Get active subscriptions (all currently valid)
+        // Get active subscriptions (all currently valid), limit 3
         $activeSubscriptions = UserSubscription::query()
             ->with('plan')
             ->where('user_id', $user->id)
-            ->where('status', 'active')
-            ->where('payment_status', 'paid')
-            ->where('current_period_end', '>', now())
+            ->active()
+            ->paid()
+            ->notExpired()
             ->orderBy('current_period_end', 'asc')
+            ->limit(3)
             ->get();
 
         // Enrich with Stripe cancel flags for display

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -42,9 +42,42 @@ class HomeController extends Controller
             ->orderBy('current_period_end', 'asc')
             ->get();
 
+        // Enrich with Stripe cancel flags for display
+        $this->appendStripeCancelFlagsToCollection($activeSubscriptions);
+
         return view('home', [
             'currentReservations' => $currentReservations,
             'activeSubscriptions' => $activeSubscriptions,
         ]);
+    }
+
+    /**
+     * Append Stripe cancel flags to a collection of subscriptions for UI display.
+     *
+     * @param  \Illuminate\Support\Collection<int, \App\Models\UserSubscription>  $items
+     */
+    private function appendStripeCancelFlagsToCollection($items): void
+    {
+        $secret = config('services.stripe.secret');
+        if (empty($secret)) {
+            return;
+        }
+
+        $client = new \Stripe\StripeClient($secret);
+        foreach ($items as $sub) {
+            $sid = (string) ($sub->stripe_subscription_id ?? '');
+            if ($sid === '') {
+                continue;
+            }
+            try {
+                $remote = $client->subscriptions->retrieve($sid, []);
+                $sub->cancel_at_period_end = (bool) ($remote->cancel_at_period_end ?? false);
+                $sub->cancel_at = isset($remote->cancel_at)
+                    ? \Carbon\Carbon::createFromTimestamp((int) $remote->cancel_at)
+                    : null;
+            } catch (\Throwable $e) {
+                // ignore
+            }
+        }
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -43,42 +43,9 @@ class HomeController extends Controller
             ->limit(3)
             ->get();
 
-        // Enrich with Stripe cancel flags for display
-        $this->appendStripeCancelFlagsToCollection($activeSubscriptions);
-
         return view('home', [
             'currentReservations' => $currentReservations,
             'activeSubscriptions' => $activeSubscriptions,
         ]);
-    }
-
-    /**
-     * Append Stripe cancel flags to a collection of subscriptions for UI display.
-     *
-     * @param  \Illuminate\Support\Collection<int, \App\Models\UserSubscription>  $items
-     */
-    private function appendStripeCancelFlagsToCollection($items): void
-    {
-        $secret = config('services.stripe.secret');
-        if (empty($secret)) {
-            return;
-        }
-
-        $client = new \Stripe\StripeClient($secret);
-        foreach ($items as $sub) {
-            $sid = (string) ($sub->stripe_subscription_id ?? '');
-            if ($sid === '') {
-                continue;
-            }
-            try {
-                $remote = $client->subscriptions->retrieve($sid, []);
-                $sub->cancel_at_period_end = (bool) ($remote->cancel_at_period_end ?? false);
-                $sub->cancel_at = isset($remote->cancel_at)
-                    ? \Carbon\Carbon::createFromTimestamp((int) $remote->cancel_at)
-                    : null;
-            } catch (\Throwable $e) {
-                // ignore
-            }
-        }
     }
 }

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -20,10 +20,7 @@ class PlanController extends Controller
             $activeSubs = $user->userSubscriptions()
                 ->active()
                 ->paid()
-                ->where(function ($q) {
-                    $q->whereNull('current_period_end')
-                        ->orWhere('current_period_end', '>=', now());
-                })
+                ->notExpired()
                 ->with('plan')
                 ->get();
             $activePriceIds = $activeSubs->pluck('plan.stripe_price_id')->filter()->values()->all();

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SubscriptionPlan;
+use Illuminate\Contracts\View\View;
+
+class PlanController extends Controller
+{
+    public function index(): View
+    {
+        $plans = SubscriptionPlan::query()
+            ->active()
+            ->orderBy('id')
+            ->get();
+
+        $activePriceIds = [];
+        if (auth()->check()) {
+            $user = auth()->user();
+            $activeSubs = $user->userSubscriptions()
+                ->active()
+                ->paid()
+                ->where(function ($q) {
+                    $q->whereNull('current_period_end')
+                        ->orWhere('current_period_end', '>=', now());
+                })
+                ->with('plan')
+                ->get();
+            $activePriceIds = $activeSubs->pluck('plan.stripe_price_id')->filter()->values()->all();
+        }
+
+        return view('plans.index', [
+            'plans' => $plans,
+            'activePriceIds' => $activePriceIds,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -58,10 +58,6 @@ class ProfileController extends Controller
     }
 
     /**
-     * Append Stripe cancel flags for paginator items.
-     */
-    // appendStripeCancelFlags removed
-    /**
      * Display the user's profile form.
      */
     public function edit(Request $request): View

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -18,15 +18,19 @@ class ProfileController extends Controller
     {
         $user = $request->user();
 
+        // Show only up to 3 latest subscriptions for the dashboard
         $subscriptions = $user->userSubscriptions()
             ->with('plan')
             ->orderByDesc('current_period_end')
-            ->paginate(config('pagination.profile_subscriptions', 10), ['*'], 'subscriptions_page');
+            ->limit(3)
+            ->get();
 
+        // Show only up to 3 recent reservations for the dashboard
         $reservations = $user->reservations()
             ->with(['lessonSchedule.lesson.store'])
             ->orderByDesc('created_at')
-            ->paginate(config('pagination.profile_reservations', 10), ['*'], 'reservations_page');
+            ->limit(3)
+            ->get();
 
         // Fetch favorite stores
         $favoriteStores = $user->favorites()

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -48,8 +48,15 @@ class ProfileController extends Controller
             ->pluck('favoritable')
             ->filter();
 
+        // Cancel flags are now persisted via webhooks; no runtime Stripe calls required
+
         return view('profile.index', compact('user', 'subscriptions', 'reservations', 'favoriteStores', 'favoriteInstructors'));
     }
+
+    /**
+     * Append Stripe cancel flags for paginator items.
+     */
+    // appendStripeCancelFlags removed
     /**
      * Display the user's profile form.
      */

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -62,7 +62,6 @@ class WebhookController extends Controller
         try {
             switch ($type) {
                 case 'checkout.session.completed':
-                    $sessionId = (string) ($event->data->object->id ?? '');
                     $subscriptionId = (string) ($event->data->object->subscription ?? '');
                     $customerId = (string) ($event->data->object->customer ?? '');
                     if ($subscriptionId !== '' && $customerId !== '') {

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -84,7 +84,6 @@ class WebhookController extends Controller
                     }
                     break;
 
-                case 'invoice.paid':
                 case 'invoice.payment_succeeded':
                     $subscriptionId = (string) ($event->data->object->subscription ?? '');
                     $customerId = (string) ($event->data->object->customer ?? '');

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -108,7 +108,7 @@ class WebhookController extends Controller
         return response('ok', 200);
     }
 
-    private function syncSubscriptionById(string $stripeSubscriptionId, string $stripeCustomerId, bool $forcePaid = false): void
+    private function getStripeClient(): StripeClient
     {
         $secret = config('services.stripe.secret');
         if (empty($secret)) {
@@ -117,7 +117,12 @@ class WebhookController extends Controller
             ]);
         }
 
-        $client = new StripeClient(['api_key' => $secret]);
+        return new StripeClient(['api_key' => $secret]);
+    }
+
+    private function syncSubscriptionById(string $stripeSubscriptionId, string $stripeCustomerId, bool $forcePaid = false): void
+    {
+        $client = $this->getStripeClient();
 
         $subscription = $client->subscriptions->retrieve($stripeSubscriptionId, [
             'expand' => ['items.data.price.product'],
@@ -186,30 +191,6 @@ class WebhookController extends Controller
             ['stripe_subscription_id'],
             array_merge(array_keys($values), ['updated_at'])
         );
-    }
-
-    private function syncSubscriptionByInvoiceId(string $invoiceId): void
-    {
-        $secret = config('services.stripe.secret');
-        if (empty($secret)) {
-            throw ValidationException::withMessages([
-                'stripe' => 'StripeのAPIキーが未設定です（.env の STRIPE_SECRET を設定してください）。',
-            ]);
-        }
-
-        $client = new StripeClient(['api_key' => $secret]);
-        try {
-            $invoice = $client->invoices->retrieve($invoiceId, []);
-        } catch (\Throwable $e) {
-            report($e);
-
-            return; // skip when invoice retrieval fails
-        }
-        $subscriptionId = (string) ($invoice->subscription ?? '');
-        $customerId = (string) ($invoice->customer ?? '');
-        if ($subscriptionId !== '' && $customerId !== '') {
-            $this->syncSubscriptionById($subscriptionId, $customerId, forcePaid: true);
-        }
     }
 
     private function mapStripeStatusToLocal(string $stripeStatus): string

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\SubscriptionPlan;
 use App\Models\User;
 use App\Models\UserSubscription;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -49,11 +50,15 @@ class WebhookController extends Controller
                 'payload' => $payload,
                 'received_at' => now(),
             ]);
-        } catch (\Throwable $e) {
-            // Unique violation or other error -> if duplicate, skip; else log and skip
-            if (str_contains(strtolower((string) $e->getMessage()), 'unique')) {
+        } catch (QueryException $e) {
+            $state = $e->errorInfo[0] ?? $e->getCode();
+            if (in_array($state, ['23000', '23505'], true)) {
                 return response('ok', 200);
             }
+            report($e);
+
+            return response('ok', 200);
+        } catch (\Throwable $e) {
             report($e);
 
             return response('ok', 200);
@@ -71,6 +76,7 @@ class WebhookController extends Controller
 
                 case 'customer.subscription.created':
                 case 'customer.subscription.updated':
+                case 'customer.subscription.deleted':
                     $subscriptionId = (string) ($event->data->object->id ?? '');
                     $customerId = (string) ($event->data->object->customer ?? '');
                     if ($subscriptionId !== '' && $customerId !== '') {
@@ -158,11 +164,11 @@ class WebhookController extends Controller
 
         // Upsert using unique key on stripe_subscription_id to avoid UNIQUE violations
         $attributes = [
+            'user_id' => $user->id,
             'stripe_subscription_id' => (string) $subscription->id,
         ];
 
         $values = [
-            'user_id' => $user->id,
             'status' => $status,
             'payment_status' => $paymentStatus,
             'current_period_start' => $periodStart,
@@ -178,7 +184,12 @@ class WebhookController extends Controller
             $values['plan_id'] = $plan->id;
         }
 
-        UserSubscription::query()->updateOrCreate($attributes, $values);
+        $row = array_merge($attributes, $values, [
+            'updated_at' => now(),
+            'created_at' => now(),
+        ]);
+        // align with DB unique constraint on (user_id, stripe_subscription_id)
+        UserSubscription::query()->upsert([$row], ['user_id', 'stripe_subscription_id'], array_keys($values) + ['updated_at']);
     }
 
     private function syncSubscriptionByInvoiceId(string $invoiceId): void
@@ -215,7 +226,6 @@ class WebhookController extends Controller
             'incomplete' => UserSubscription::STATUS_INCOMPLETE,
             'incomplete_expired' => UserSubscription::STATUS_INCOMPLETE_EXPIRED,
             'unpaid' => UserSubscription::STATUS_UNPAID,
-            'paused' => UserSubscription::STATUS_PAUSED,
             default => UserSubscription::STATUS_UNKNOWN,
         };
     }

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace App\Http\Controllers\Stripe;
+
+use App\Http\Controllers\Controller;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+use Stripe\StripeClient;
+use Stripe\Webhook as StripeWebhook;
+
+class WebhookController extends Controller
+{
+    public function handle(Request $request): Response
+    {
+        $payload = $request->getContent();
+        $signature = (string) $request->header('Stripe-Signature');
+        $secret = (string) (config('services.stripe.webhook.secret') ?? '');
+        if ($secret === '') {
+            Log::error('Stripe webhook secret not configured');
+
+            return response('server not configured', 500);
+        }
+
+        try {
+            $event = StripeWebhook::constructEvent($payload, $signature, $secret);
+        } catch (\Throwable $e) {
+            report($e);
+
+            return response('invalid signature', 400);
+        }
+
+        $type = (string) ($event->type ?? '');
+        $eventId = (string) ($event->id ?? '');
+        if ($eventId === '') {
+            return response('ok', 200);
+        }
+
+        // Idempotency guard using DB unique event store
+        try {
+            DB::table('stripe_webhook_events')->insert([
+                'event_id' => $eventId,
+                'type' => $type,
+                'payload' => $payload,
+                'received_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            // Unique violation or other error -> if duplicate, skip; else log and skip
+            if (str_contains(strtolower((string) $e->getMessage()), 'unique')) {
+                return response('ok', 200);
+            }
+            report($e);
+
+            return response('ok', 200);
+        }
+
+        try {
+            switch ($type) {
+                case 'checkout.session.completed':
+                    $sessionId = (string) ($event->data->object->id ?? '');
+                    $subscriptionId = (string) ($event->data->object->subscription ?? '');
+                    $customerId = (string) ($event->data->object->customer ?? '');
+                    if ($subscriptionId !== '' && $customerId !== '') {
+                        $this->syncSubscriptionById($subscriptionId, $customerId);
+                    }
+                    break;
+
+                case 'customer.subscription.created':
+                case 'customer.subscription.updated':
+                    $subscriptionId = (string) ($event->data->object->id ?? '');
+                    $customerId = (string) ($event->data->object->customer ?? '');
+                    if ($subscriptionId !== '' && $customerId !== '') {
+                        $this->syncSubscriptionById($subscriptionId, $customerId);
+                    }
+                    break;
+
+                case 'invoice.paid':
+                case 'invoice.payment_succeeded':
+                    $subscriptionId = (string) ($event->data->object->subscription ?? '');
+                    $customerId = (string) ($event->data->object->customer ?? '');
+                    if ($subscriptionId !== '' && $customerId !== '') {
+                        $this->syncSubscriptionById($subscriptionId, $customerId, forcePaid: true);
+                    }
+                    break;
+
+                case 'invoice_payment.paid':
+                    // Newer API: object is invoice_payment; fetch invoice to resolve customer/subscription
+                    $invoiceId = (string) ($event->data->object->invoice ?? '');
+                    if ($invoiceId !== '') {
+                        $this->syncSubscriptionByInvoiceId($invoiceId);
+                    }
+                    break;
+
+                default:
+                    // Ignore other events
+                    break;
+            }
+        } catch (\Throwable $e) {
+            report($e);
+            // still 200 per Stripe recommendations (avoid retries on persistent app errors)
+        }
+
+        // mark processed
+        DB::table('stripe_webhook_events')->where('event_id', $eventId)->update(['processed_at' => now()]);
+
+        return response('ok', 200);
+    }
+
+    private function syncSubscriptionById(string $stripeSubscriptionId, string $stripeCustomerId, bool $forcePaid = false): void
+    {
+        $secret = config('services.stripe.secret');
+        if (empty($secret)) {
+            throw ValidationException::withMessages([
+                'stripe' => 'StripeのAPIキーが未設定です（.env の STRIPE_SECRET を設定してください）。',
+            ]);
+        }
+
+        $client = new StripeClient(['api_key' => $secret]);
+
+        $subscription = $client->subscriptions->retrieve($stripeSubscriptionId, [
+            'expand' => ['items.data.price.product'],
+        ]);
+
+        $user = User::query()->where('stripe_id', $stripeCustomerId)->first();
+        if (! $user) {
+            Log::warning('Webhook subscription sync: user not found for customer', [
+                'customer' => $stripeCustomerId,
+                'subscription' => $stripeSubscriptionId,
+            ]);
+
+            return;
+        }
+
+        $priceId = null;
+        if (isset($subscription->items) && isset($subscription->items->data) && ! empty($subscription->items->data)) {
+            $first = $subscription->items->data[0] ?? null;
+            if ($first && isset($first->price) && isset($first->price->id)) {
+                $priceId = $first->price->id;
+            }
+        }
+        $plan = $priceId ? SubscriptionPlan::query()->where('stripe_price_id', $priceId)->first() : null;
+
+        $status = $this->mapStripeStatusToLocal((string) ($subscription->status ?? ''));
+        $paymentStatus = $forcePaid || in_array($status, [UserSubscription::STATUS_ACTIVE, UserSubscription::STATUS_TRIALING], true)
+            ? UserSubscription::PAYMENT_STATUS_PAID
+            : UserSubscription::PAYMENT_STATUS_UNPAID;
+
+        $periodStart = isset($subscription->current_period_start)
+            ? \Carbon\Carbon::createFromTimestamp((int) $subscription->current_period_start)
+            : null;
+        $periodEnd = isset($subscription->current_period_end)
+            ? \Carbon\Carbon::createFromTimestamp((int) $subscription->current_period_end)
+            : null;
+
+        // Upsert using unique key on stripe_subscription_id to avoid UNIQUE violations
+        $attributes = [
+            'stripe_subscription_id' => (string) $subscription->id,
+        ];
+
+        $values = [
+            'user_id' => $user->id,
+            'status' => $status,
+            'payment_status' => $paymentStatus,
+            'current_period_start' => $periodStart,
+            'current_period_end' => $periodEnd,
+            // Persist cancel flags to avoid N+1 fetches on UI
+            'cancel_at_period_end' => (bool) ($subscription->cancel_at_period_end ?? false),
+            'cancel_at' => isset($subscription->cancel_at)
+                ? \Carbon\Carbon::createFromTimestamp((int) $subscription->cancel_at)
+                : null,
+        ];
+
+        if ($plan) {
+            $values['plan_id'] = $plan->id;
+        }
+
+        UserSubscription::query()->updateOrCreate($attributes, $values);
+    }
+
+    private function syncSubscriptionByInvoiceId(string $invoiceId): void
+    {
+        $secret = config('services.stripe.secret');
+        if (empty($secret)) {
+            throw ValidationException::withMessages([
+                'stripe' => 'StripeのAPIキーが未設定です（.env の STRIPE_SECRET を設定してください）。',
+            ]);
+        }
+
+        $client = new StripeClient(['api_key' => $secret]);
+        try {
+            $invoice = $client->invoices->retrieve($invoiceId, []);
+        } catch (\Throwable $e) {
+            report($e);
+
+            return; // skip when invoice retrieval fails
+        }
+        $subscriptionId = (string) ($invoice->subscription ?? '');
+        $customerId = (string) ($invoice->customer ?? '');
+        if ($subscriptionId !== '' && $customerId !== '') {
+            $this->syncSubscriptionById($subscriptionId, $customerId, forcePaid: true);
+        }
+    }
+
+    private function mapStripeStatusToLocal(string $stripeStatus): string
+    {
+        return match ($stripeStatus) {
+            'active' => UserSubscription::STATUS_ACTIVE,
+            'trialing' => UserSubscription::STATUS_TRIALING,
+            'past_due' => UserSubscription::STATUS_PAST_DUE,
+            'canceled' => UserSubscription::STATUS_CANCELED,
+            'incomplete' => UserSubscription::STATUS_INCOMPLETE,
+            'incomplete_expired' => UserSubscription::STATUS_INCOMPLETE_EXPIRED,
+            'unpaid' => UserSubscription::STATUS_UNPAID,
+            'paused' => UserSubscription::STATUS_PAUSED,
+            default => UserSubscription::STATUS_UNKNOWN,
+        };
+    }
+}

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -93,14 +93,6 @@ class WebhookController extends Controller
                     }
                     break;
 
-                case 'invoice_payment.paid':
-                    // Newer API: object is invoice_payment; fetch invoice to resolve customer/subscription
-                    $invoiceId = (string) ($event->data->object->invoice ?? '');
-                    if ($invoiceId !== '') {
-                        $this->syncSubscriptionByInvoiceId($invoiceId);
-                    }
-                    break;
-
                 default:
                     // Ignore other events
                     break;
@@ -188,8 +180,12 @@ class WebhookController extends Controller
             'updated_at' => now(),
             'created_at' => now(),
         ]);
-        // align with DB unique constraint on (user_id, stripe_subscription_id)
-        UserSubscription::query()->upsert([$row], ['user_id', 'stripe_subscription_id'], array_keys($values) + ['updated_at']);
+        // align with DB unique constraint on stripe_subscription_id
+        UserSubscription::query()->upsert(
+            [$row],
+            ['stripe_subscription_id'],
+            array_merge(array_keys($values), ['updated_at'])
+        );
     }
 
     private function syncSubscriptionByInvoiceId(string $invoiceId): void

--- a/app/Http/Controllers/Stripe/WebhookController.php
+++ b/app/Http/Controllers/Stripe/WebhookController.php
@@ -53,11 +53,17 @@ class WebhookController extends Controller
         } catch (QueryException $e) {
             $state = $e->errorInfo[0] ?? $e->getCode();
             if (in_array($state, ['23000', '23505'], true)) {
+                // Duplicate event: continue only if not processed yet; otherwise ack
+                $existing = DB::table('stripe_webhook_events')->where('event_id', $eventId)->first();
+                if (! $existing || $existing->processed_at !== null) {
+                    return response('ok', 200);
+                }
+                // fall-through to processing when processed_at is null
+            } else {
+                report($e);
+
                 return response('ok', 200);
             }
-            report($e);
-
-            return response('ok', 200);
         } catch (\Throwable $e) {
             report($e);
 
@@ -98,11 +104,14 @@ class WebhookController extends Controller
             }
         } catch (\Throwable $e) {
             report($e);
-            // still 200 per Stripe recommendations (avoid retries on persistent app errors)
+
+            return response('failed to process', 500);
         }
 
-        // mark processed
-        DB::table('stripe_webhook_events')->where('event_id', $eventId)->update(['processed_at' => now()]);
+        // mark processed on success only
+        DB::table('stripe_webhook_events')
+            ->where('event_id', $eventId)
+            ->update(['processed_at' => now()]);
 
         return response('ok', 200);
     }

--- a/app/Http/Controllers/Subscription/ManageController.php
+++ b/app/Http/Controllers/Subscription/ManageController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\Subscription;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Subscription\CancelRequest;
+use App\Http\Requests\Subscription\SwitchRequest;
+use App\Models\SubscriptionPlan;
+use App\Models\UserSubscription;
+use App\Services\SubscriptionService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ManageController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+
+        $now = now();
+
+        $active = $user->userSubscriptions()
+            ->with('plan')
+            ->where('status', UserSubscription::STATUS_ACTIVE)
+            ->where('payment_status', UserSubscription::PAYMENT_STATUS_PAID)
+            ->where(function ($q) use ($now) {
+                $q->whereNull('current_period_end')
+                    ->orWhere('current_period_end', '>=', $now);
+            })
+            ->orderBy('current_period_end')
+            ->paginate(config('pagination.profile_subscriptions', 10), ['*'], 'active_page');
+
+        $past = $user->userSubscriptions()
+            ->with('plan')
+            ->where(function ($q) use ($now) {
+                $q->where('status', UserSubscription::STATUS_CANCELED)
+                    ->orWhere(function ($q2) use ($now) {
+                        $q2->where('status', UserSubscription::STATUS_ACTIVE)
+                            ->whereNotNull('current_period_end')
+                            ->where('current_period_end', '<', $now);
+                    });
+            })
+            ->orderByDesc('current_period_end')
+            ->paginate(config('pagination.profile_subscriptions', 10), ['*'], 'past_page');
+
+        // Cancel flags are now persisted on user_subscriptions via webhooks.
+
+        return view('subscriptions.manage', [
+            'active' => $active,
+            'past' => $past,
+        ]);
+    }
+
+    public function switch(SwitchRequest $request, SubscriptionService $service): RedirectResponse
+    {
+        $user = $request->user();
+        $data = $request->validated();
+
+        $from = SubscriptionPlan::query()->findOrFail((int) $data['from_plan_id']);
+        $to = SubscriptionPlan::query()->findOrFail((int) $data['to_plan_id']);
+
+        $session = $service->switchPlan($user, $from, $to);
+
+        return redirect()->away($session->url);
+    }
+
+    public function cancel(CancelRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $data = $request->validated();
+
+        /** @var UserSubscription $subscription */
+        $subscription = $user->userSubscriptions()->with('plan')->findOrFail((int) $data['subscription_id']);
+
+        // 既にキャンセル済みなら何もしない
+        if ($subscription->status === UserSubscription::STATUS_CANCELED) {
+            return back()->with('status', 'すでにキャンセル済みのサブスクリプションです');
+        }
+
+        // Stripe の購読を期末解約に設定
+        $stripeId = (string) $subscription->stripe_subscription_id;
+        if ($stripeId === '') {
+            return back()->withErrors(['subscription' => 'Stripe購読IDが見つかりません。']);
+        }
+
+        $secret = config('services.stripe.secret');
+        if (empty($secret)) {
+            return back()->withErrors(['subscription' => 'StripeのAPIキーが未設定です。']);
+        }
+
+        try {
+            $client = new \Stripe\StripeClient($secret);
+            // 期末解約（即時キャンセルではない）
+            $client->subscriptions->update($stripeId, [
+                'cancel_at_period_end' => true,
+            ]);
+        } catch (\Throwable $e) {
+            report($e);
+
+            return back()->withErrors(['subscription' => '解約処理に失敗しました。しばらくしてから再度お試しください。']);
+        }
+
+        // Webhook (customer.subscription.updated) で同期される想定
+        return back()->with('status', '期末での解約を受け付けました。');
+    }
+
+    /**
+     * Append Stripe cancel flags (cancel_at_period_end/cancel_at) to subscription models for display.
+     */
+    // appendStripeCancelFlags removed: no longer needed
+}

--- a/app/Http/Controllers/Subscription/ManageController.php
+++ b/app/Http/Controllers/Subscription/ManageController.php
@@ -90,7 +90,9 @@ class ManageController extends Controller
         }
 
         try {
-            $client = new \Stripe\StripeClient($secret);
+            $client = new \Stripe\StripeClient([
+                'api_key' => $secret,
+            ]);
             // 期末解約（即時キャンセルではない）
             $client->subscriptions->update($stripeId, [
                 'cancel_at_period_end' => true,

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\SubscriptionPlan;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -14,11 +13,12 @@ class SubscriptionController extends Controller
     /**
      * Create a Stripe Checkout Session for the given plan and redirect user.
      */
-    public function createCheckoutSession(Request $request, int $planId): RedirectResponse
+    public function createCheckoutSession(Request $request, \App\Models\SubscriptionPlan $plan): RedirectResponse
     {
         $user = $request->user();
 
-        $plan = SubscriptionPlan::query()->active()->findOrFail($planId);
+        // Ensure plan is active
+        abort_unless((bool) $plan->is_active, 404);
 
         // 既存の同一プラン（同一Price）への重複加入を抑止
         if (method_exists($user, 'subscribedToPrice') && $user->subscribedToPrice($plan->stripe_price_id)) {
@@ -47,10 +47,12 @@ class SubscriptionController extends Controller
         }
 
         try {
-            // 同一ユーザー×プランの短期的な二重発行を抑止
-            // フロント付与のIdempotency-Keyを優先。無ければセッションID由来の安定キーを生成
-            $idemKey = $request->header('Idempotency-Key')
-                ?? ('checkout:'.hash('sha256', $user->getKey().':'.$plan->getKey().':'.$request->session()->getId()));
+            // フロント付与の Idempotency-Key がある場合のみ Stripe に伝播する
+            // 既定では毎回新規 Checkout Session を作成し、完了/失効済みセッションの再利用を避ける
+            $createOpts = [];
+            if ($request->hasHeader('Idempotency-Key')) {
+                $createOpts['idempotency_key'] = $request->header('Idempotency-Key');
+            }
             $session = $this->stripe()->checkout->sessions->create([
                 'mode' => 'subscription',
                 'customer' => $user->stripe_id,
@@ -74,9 +76,7 @@ class SubscriptionController extends Controller
                 ],
                 // Optional: enable promotion codes in future if needed
                 // 'allow_promotion_codes' => true,
-            ], [
-                'idempotency_key' => $idemKey,
-            ]);
+            ], $createOpts);
         } catch (\Throwable $e) {
             report($e);
             if ($e instanceof \Stripe\Exception\ApiErrorException) {
@@ -129,7 +129,6 @@ class SubscriptionController extends Controller
 
         $client = new StripeClient([
             'api_key' => $secret,
-            'max_network_retries' => 2,
         ]);
 
         return $client;

--- a/app/Http/Requests/Subscription/CancelRequest.php
+++ b/app/Http/Requests/Subscription/CancelRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Subscription;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CancelRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'subscription_id' => ['required', 'integer', 'exists:user_subscriptions,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Subscription/SwitchRequest.php
+++ b/app/Http/Requests/Subscription/SwitchRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Subscription;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SwitchRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'from_plan_id' => ['required', 'integer', 'exists:subscription_plans,id'],
+            'to_plan_id' => ['required', 'integer', 'different:from_plan_id', 'exists:subscription_plans,id'],
+        ];
+    }
+}

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -122,6 +122,17 @@ class UserSubscription extends Model
     }
 
     /**
+     * Scope a query to subscriptions that are not yet expired (no end or end in future).
+     */
+    public function scopeNotExpired(Builder $query): Builder
+    {
+        return $query->where(function (Builder $q): void {
+            $q->whereNull('current_period_end')
+                ->orWhere('current_period_end', '>=', now());
+        });
+    }
+
+    /**
      * Scope by lesson category allowed by the plan.
      */
     public function scopeForCategory(Builder $query, int $categoryId): Builder
@@ -247,37 +258,17 @@ class UserSubscription extends Model
      */
     public function getStatusLabelAttribute(): string
     {
-        $keyFor = static fn (string $k): string => "subscription.status.$k";
-
-        $label = match ($this->status) {
-            self::STATUS_ACTIVE => __($keyFor(self::STATUS_ACTIVE)),
-            self::STATUS_CANCELED => __($keyFor(self::STATUS_CANCELED)),
-            self::STATUS_PAST_DUE => __($keyFor(self::STATUS_PAST_DUE)),
-            self::STATUS_TRIALING => __($keyFor(self::STATUS_TRIALING)),
-            self::STATUS_INCOMPLETE => __($keyFor(self::STATUS_INCOMPLETE)),
-            self::STATUS_INCOMPLETE_EXPIRED => __($keyFor(self::STATUS_INCOMPLETE_EXPIRED)),
-            self::STATUS_UNPAID => __($keyFor(self::STATUS_UNPAID)),
-            self::STATUS_PAUSED => __($keyFor(self::STATUS_PAUSED)),
-            self::STATUS_UNKNOWN => __($keyFor(self::STATUS_UNKNOWN)),
+        return match ($this->status) {
+            self::STATUS_ACTIVE => __('subscription.status.active'),
+            self::STATUS_CANCELED => __('subscription.status.canceled'),
+            self::STATUS_PAST_DUE => __('subscription.status.past_due'),
+            self::STATUS_TRIALING => __('subscription.status.trialing'),
+            self::STATUS_INCOMPLETE => __('subscription.status.incomplete'),
+            self::STATUS_INCOMPLETE_EXPIRED => __('subscription.status.incomplete_expired'),
+            self::STATUS_UNPAID => __('subscription.status.unpaid'),
+            self::STATUS_PAUSED => __('subscription.status.paused'),
+            self::STATUS_UNKNOWN => __('subscription.status.unknown'),
             default => (string) $this->status,
         };
-
-        // Fallback: if translation not found, __() returns the key itself
-        if (is_string($label) && str_starts_with($label, 'subscription.status.')) {
-            return match ($this->status) {
-                self::STATUS_ACTIVE => '有効',
-                self::STATUS_CANCELED => 'キャンセル済み',
-                self::STATUS_PAST_DUE => '支払い遅延',
-                self::STATUS_TRIALING => 'トライアル中',
-                self::STATUS_INCOMPLETE => '未完了',
-                self::STATUS_INCOMPLETE_EXPIRED => '未完了（期限切れ）',
-                self::STATUS_UNPAID => '未払い',
-                self::STATUS_PAUSED => '一時停止',
-                self::STATUS_UNKNOWN => '不明',
-                default => (string) $this->status,
-            };
-        }
-
-        return $label;
     }
 }

--- a/app/Models/UserSubscription.php
+++ b/app/Models/UserSubscription.php
@@ -20,6 +20,16 @@ class UserSubscription extends Model
 
     public const STATUS_PAST_DUE = 'past_due';
 
+    public const STATUS_INCOMPLETE = 'incomplete';
+
+    public const STATUS_INCOMPLETE_EXPIRED = 'incomplete_expired';
+
+    public const STATUS_UNPAID = 'unpaid';
+
+    public const STATUS_PAUSED = 'paused';
+
+    public const STATUS_UNKNOWN = 'unknown';
+
     public const PAYMENT_STATUS_PAID = 'paid';
 
     public const PAYMENT_STATUS_UNPAID = 'unpaid';
@@ -33,6 +43,11 @@ class UserSubscription extends Model
         self::STATUS_TRIALING,
         self::STATUS_CANCELED,
         self::STATUS_PAST_DUE,
+        self::STATUS_INCOMPLETE,
+        self::STATUS_INCOMPLETE_EXPIRED,
+        self::STATUS_UNPAID,
+        self::STATUS_PAUSED,
+        self::STATUS_UNKNOWN,
     ];
 
     public const ALLOWED_PAYMENT_STATUSES = [
@@ -53,6 +68,8 @@ class UserSubscription extends Model
         'current_period_end',
         'current_month_used_count',
         'remaining_lessons',
+        'cancel_at_period_end',
+        'cancel_at',
     ];
 
     protected $casts = [
@@ -60,6 +77,8 @@ class UserSubscription extends Model
         'current_period_end' => 'datetime',
         'current_month_used_count' => 'integer',
         'remaining_lessons' => 'integer',
+        'cancel_at_period_end' => 'boolean',
+        'cancel_at' => 'datetime',
     ];
 
     /**
@@ -228,12 +247,37 @@ class UserSubscription extends Model
      */
     public function getStatusLabelAttribute(): string
     {
-        return match ($this->status) {
-            self::STATUS_ACTIVE => __('subscription.status.active'),
-            self::STATUS_CANCELED => __('subscription.status.canceled'),
-            self::STATUS_PAST_DUE => __('subscription.status.past_due'),
-            self::STATUS_TRIALING => __('subscription.status.trialing'),
+        $keyFor = static fn (string $k): string => "subscription.status.$k";
+
+        $label = match ($this->status) {
+            self::STATUS_ACTIVE => __($keyFor(self::STATUS_ACTIVE)),
+            self::STATUS_CANCELED => __($keyFor(self::STATUS_CANCELED)),
+            self::STATUS_PAST_DUE => __($keyFor(self::STATUS_PAST_DUE)),
+            self::STATUS_TRIALING => __($keyFor(self::STATUS_TRIALING)),
+            self::STATUS_INCOMPLETE => __($keyFor(self::STATUS_INCOMPLETE)),
+            self::STATUS_INCOMPLETE_EXPIRED => __($keyFor(self::STATUS_INCOMPLETE_EXPIRED)),
+            self::STATUS_UNPAID => __($keyFor(self::STATUS_UNPAID)),
+            self::STATUS_PAUSED => __($keyFor(self::STATUS_PAUSED)),
+            self::STATUS_UNKNOWN => __($keyFor(self::STATUS_UNKNOWN)),
             default => (string) $this->status,
         };
+
+        // Fallback: if translation not found, __() returns the key itself
+        if (is_string($label) && str_starts_with($label, 'subscription.status.')) {
+            return match ($this->status) {
+                self::STATUS_ACTIVE => '有効',
+                self::STATUS_CANCELED => 'キャンセル済み',
+                self::STATUS_PAST_DUE => '支払い遅延',
+                self::STATUS_TRIALING => 'トライアル中',
+                self::STATUS_INCOMPLETE => '未完了',
+                self::STATUS_INCOMPLETE_EXPIRED => '未完了（期限切れ）',
+                self::STATUS_UNPAID => '未払い',
+                self::STATUS_PAUSED => '一時停止',
+                self::STATUS_UNKNOWN => '不明',
+                default => (string) $this->status,
+            };
+        }
+
+        return $label;
     }
 }

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -50,6 +50,19 @@ class SubscriptionService
             ]);
         }
 
+        // Guard: prevent switching to a plan the user already has active and paid (not expired)
+        $alreadyHasTarget = $user->userSubscriptions()
+            ->where('plan_id', $to->getKey())
+            ->active()
+            ->paid()
+            ->notExpired()
+            ->exists();
+        if ($alreadyHasTarget) {
+            throw ValidationException::withMessages([
+                'subscription' => '既に切替先の有効なサブスクリプションをお持ちです。',
+            ]);
+        }
+
         // Calculate remaining lessons (hint only). Final value is recalculated at webhook time.
         $remaining = max(0, (int) $from->lesson_count - (int) $current->current_month_used_count);
 

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -59,7 +59,7 @@ class SubscriptionService
             ->exists();
         if ($alreadyHasTarget) {
             throw ValidationException::withMessages([
-                'subscription' => '既に切替先の有効なサブスクリプションをお持ちです。',
+                'subscription' => trans('subscription.errors.switch_target_exists'),
             ]);
         }
 

--- a/database/migrations/2025_10_03_085528_create_stripe_webhook_events_table.php
+++ b/database/migrations/2025_10_03_085528_create_stripe_webhook_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stripe_webhook_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('event_id')->unique();
+            $table->string('type')->nullable();
+            $table->json('payload')->nullable();
+            $table->timestamp('received_at')->useCurrent();
+            $table->timestamp('processed_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stripe_webhook_events');
+    }
+};

--- a/database/migrations/2025_10_03_085532_add_cancel_columns_and_unique_to_user_subscriptions.php
+++ b/database/migrations/2025_10_03_085532_add_cancel_columns_and_unique_to_user_subscriptions.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            if (! Schema::hasColumn('user_subscriptions', 'cancel_at_period_end')) {
+                $table->boolean('cancel_at_period_end')->default(false)->after('remaining_lessons');
+            }
+            if (! Schema::hasColumn('user_subscriptions', 'cancel_at')) {
+                $table->timestamp('cancel_at')->nullable()->after('cancel_at_period_end');
+            }
+
+            // Composite unique index to prevent duplicates per user-subscription pair
+            $table->unique(['user_id', 'stripe_subscription_id'], 'user_subscriptions_user_stripe_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            if (Schema::hasColumn('user_subscriptions', 'cancel_at')) {
+                $table->dropColumn('cancel_at');
+            }
+            if (Schema::hasColumn('user_subscriptions', 'cancel_at_period_end')) {
+                $table->dropColumn('cancel_at_period_end');
+            }
+            $table->dropUnique('user_subscriptions_user_stripe_unique');
+        });
+    }
+};

--- a/database/migrations/2025_10_03_100000_drop_composite_unique_from_user_subscriptions.php
+++ b/database/migrations/2025_10_03_100000_drop_composite_unique_from_user_subscriptions.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -22,6 +23,17 @@ return new class extends Migration
      */
     public function down(): void
     {
+        // 重複データがあると複合ユニーク再作成で失敗するため安全確認
+        $duplicates = DB::table('user_subscriptions')
+            ->select('user_id', 'stripe_subscription_id', DB::raw('count(*) as count'))
+            ->groupBy('user_id', 'stripe_subscription_id')
+            ->havingRaw('count(*) > 1')
+            ->get();
+
+        if ($duplicates->isNotEmpty()) {
+            throw new \RuntimeException('Duplicate (user_id, stripe_subscription_id) found. Cannot rollback safely.');
+        }
+
         Schema::table('user_subscriptions', function (Blueprint $table) {
             // ロールバック時は複合ユニークを再作成
             $table->unique(['user_id', 'stripe_subscription_id'], 'user_subscriptions_user_stripe_unique');

--- a/database/migrations/2025_10_03_100000_drop_composite_unique_from_user_subscriptions.php
+++ b/database/migrations/2025_10_03_100000_drop_composite_unique_from_user_subscriptions.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            // 複合ユニーク制約を削除（単一ユニーク stripe_subscription_id のみを使用）
+            $table->dropUnique('user_subscriptions_user_stripe_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_subscriptions', function (Blueprint $table) {
+            // ロールバック時は複合ユニークを再作成
+            $table->unique(['user_id', 'stripe_subscription_id'], 'user_subscriptions_user_stripe_unique');
+        });
+    }
+};

--- a/resources/lang/ja/subscription.php
+++ b/resources/lang/ja/subscription.php
@@ -6,6 +6,11 @@ return [
         'canceled' => 'キャンセル済み',
         'past_due' => '支払い遅延',
         'trialing' => 'トライアル中',
+        'incomplete' => '未完了',
+        'incomplete_expired' => '未完了（期限切れ）',
+        'unpaid' => '未払い',
+        'paused' => '一時停止',
+        'unknown' => '不明',
     ],
     'errors' => [
         'count_limit_reached' => 'ご利用可能な回数が上限に達しました。次回の期間開始後にお試しください。',

--- a/resources/lang/ja/subscription.php
+++ b/resources/lang/ja/subscription.php
@@ -18,6 +18,7 @@ return [
         'payment_failed_grace' => 'お支払いに失敗しました。3日間の猶予期間中にお手続きをお願いします。',
         'plan_switch_invalid' => 'プラン切り替えに失敗しました。条件を確認して再度お試しください。',
         'checkout_failed' => '決済セッションの作成に失敗しました。時間をおいて再度お試しください。',
+        'switch_target_exists' => '既に切替先の有効なサブスクリプションをお持ちです。',
     ],
     'success' => [
         'reservation_canceled_refund' => '期限前キャンセルのため回数を戻しました。',

--- a/resources/views/components/subscription/simple-card.blade.php
+++ b/resources/views/components/subscription/simple-card.blade.php
@@ -13,7 +13,7 @@
             <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
                 次回支払日
                 <span class="ml-2 font-medium">
-                    @if(isset($subscription->cancel_at_period_end) && $subscription->cancel_at_period_end === true)
+                    @if((bool) ($subscription->cancel_at_period_end ?? false))
                         解約のため無し
                     @else
                         {{ $subscription->current_period_end?->format('Y年m月d日') ?? '未定' }}

--- a/resources/views/components/subscription/simple-card.blade.php
+++ b/resources/views/components/subscription/simple-card.blade.php
@@ -1,0 +1,25 @@
+@props(['subscription'])
+
+<div class="bg-gray-50 dark:bg-gray-700/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_2px_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_2px_0_rgba(0,0,0,0.1)] rounded-lg p-4">
+    <div class="flex justify-between items-start">
+        <div class="flex-1">
+            <h4 class="font-medium text-gray-900 dark:text-gray-100">{{ $subscription->plan?->name ?? '未設定' }}</h4>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                残り回数
+                <span class="ml-2 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-xs font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_1px_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_1px_0_rgba(0,0,0,0.1)]">
+                    {{ $subscription->remaining_lessons ?? $subscription->plan?->lesson_count }}
+                </span>
+            </p>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                次回支払日
+                <span class="ml-2 font-medium">
+                    @if(isset($subscription->cancel_at_period_end) && $subscription->cancel_at_period_end === true)
+                        解約のため無し
+                    @else
+                        {{ $subscription->current_period_end?->format('Y年m月d日') ?? '未定' }}
+                    @endif
+                </span>
+            </p>
+        </div>
+    </div>
+</div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -53,29 +53,14 @@
 
         <!-- Active Subscriptions Section -->
         <div class="flex items-center justify-between mt-4 mb-2">
-            <h3 class="text-xl font-extrabold text-gray-900 dark:text-gray-100">月謝一覧</h3>
-            <a href="#" class="text-indigo-600 dark:text-indigo-400 text-sm font-semibold hover:underline">すべて表示</a>
+            <h3 class="text-xl font-extrabold text-gray-900 dark:text-gray-100">プラン一覧</h3>
+            <a href="{{ route('subscriptions.manage') }}" class="text-indigo-600 dark:text-indigo-400 text-sm font-semibold hover:underline">すべて表示</a>
         </div>
 
         <div class="bg-white dark:bg-gray-800 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1),0_1px_3px_0_rgba(0,0,0,0.1),0_1px_2px_-1px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05),0_1px_3px_0_rgba(0,0,0,0.3),0_1px_2px_-1px_rgba(0,0,0,0.3)] rounded-xl p-6 mt-4">
-                    <div class="space-y-3">
+            <div class="space-y-3">
                 @forelse($activeSubscriptions as $subscription)
-                    <div class="bg-gray-50 dark:bg-gray-700/50 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1),0_1px_2px_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05),0_1px_2px_0_rgba(0,0,0,0.1)] rounded-lg p-4">
-                                <div class="flex justify-between items-start">
-                                    <div class="flex-1">
-                                <h4 class="font-medium text-gray-900 dark:text-gray-100">{{ $subscription->plan?->name }}</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">
-                                    残り回数
-                                    <span class="ml-2 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-xs font-medium shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1),0_1px_1px_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05),0_1px_1px_0_rgba(0,0,0,0.1)]">
-                                        {{ $subscription->remaining_lessons ?? $subscription->plan?->lesson_count }}
-                                    </span>
-                                </p>
-                                <p class="text-sm text-gray-600 dark:text-gray-400">
-                                    次回支払日<span class="ml-2 font-medium">{{ $subscription->current_period_end?->format('Y年m月d日') }}</span>
-                                </p>
-                            </div>
-                    </div>
-                    </div>
+                    <x-subscription.simple-card :subscription="$subscription" />
                 @empty
                     <div class="py-2 text-center text-sm text-gray-500 dark:text-gray-400">契約中のプランはありません</div>
                 @endforelse

--- a/resources/views/plans/index.blade.php
+++ b/resources/views/plans/index.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">プラン一覧</h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        @if($plans->isEmpty())
+            <p class="text-sm text-gray-600 dark:text-gray-400">現在申し込み可能なプランはありません。</p>
+        @else
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                @foreach($plans as $plan)
+                    <div class="rounded-xl bg-white dark:bg-gray-800 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)] hover:shadow-md transition">
+                        <h3 class="font-semibold text-gray-900 dark:text-gray-100">{{ $plan->name }}</h3>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">月額: {{ number_format($plan->price) }}円</p>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">月{{ (int) $plan->lesson_count }}回まで</p>
+                        @if($plan->description)
+                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ $plan->description }}</p>
+                        @endif
+                        <div class="mt-3">
+                            @php
+                                $isActiveForUser = auth()->check() && in_array($plan->stripe_price_id, $activePriceIds ?? [], true);
+                            @endphp
+                            @if(Route::has('subscription.checkout'))
+                                @if($isActiveForUser)
+                                    <button type="button" disabled aria-disabled="true" class="inline-flex items-center px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-700 rounded-md font-semibold text-xs text-indigo-700 dark:text-indigo-300 uppercase tracking-widest cursor-not-allowed">申し込み済み</button>
+                                @else
+                                    <a href="{{ route('subscription.checkout', ['plan' => $plan->id]) }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 dark:bg-indigo-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">申し込む</a>
+                                @endif
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+    @include('layouts.user-footer')
+</x-app-layout>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -7,26 +7,6 @@
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">契約中のプラン</h3>
-            @if($subscriptions->isEmpty())
-                <p class="text-sm text-gray-600 dark:text-gray-400">契約中のプランはありません。</p>
-            @else
-                <ul class="space-y-3">
-                    @foreach($subscriptions as $sub)
-                        <li class="flex items-center justify-between">
-                            <div>
-                                <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $sub->plan?->name ?? '未設定' }}</p>
-                                <p class="text-sm text-gray-600 dark:text-gray-400">次回支払日: {{ $sub->current_period_end?->format('Y年n月j日') ?? '未設定' }}</p>
-                            </div>
-                            <span class="text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">{{ $sub->status_label }}</span>
-                        </li>
-                    @endforeach
-                </ul>
-                <div class="mt-4">{{ $subscriptions->links() }}</div>
-            @endif
-        </div>
-
-        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">予約履歴</h3>
                 <a href="{{ route('reservations.history') }}" class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300">すべて表示 →</a>
@@ -55,6 +35,25 @@
             @endif
         </div>
 
+        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">契約中のプラン</h3>
+                <a href="{{ route('subscriptions.manage') }}" class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300">すべて表示 →</a>
+            </div>
+            @if($subscriptions->isEmpty())
+                <p class="text-sm text-gray-600 dark:text-gray-400">契約中のプランはありません。</p>
+            @else
+                <ul class="space-y-3">
+                    @foreach($subscriptions as $sub)
+                        <li>
+                            <x-subscription.simple-card :subscription="$sub" />
+                        </li>
+                    @endforeach
+                </ul>
+                <div class="mt-4">{{ $subscriptions->links() }}</div>
+            @endif
+        </div>
+
         {{-- Favorites Section --}}
         <div>
             <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">お気に入り一覧</h3>
@@ -73,9 +72,15 @@
                         <ul class="space-y-2 sm:space-y-3">
                             @foreach($favoriteStores as $store)
                                 <li>
-                                    <a href="{{ route('stores.show', $store) }}" class="block hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition">
-                                        <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium">{{ $store->name }}</p>
-                                        <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400">{{ $store->address }}</p>
+                                    <a href="{{ route('stores.show', $store) }}" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
+                                        <span class="pointer-events-none absolute inset-0 group-active:bg-gray-200/30 dark:group-active:bg-white/10 transition"></span>
+                                        <div class="py-1 sm:py-0 flex-1">
+                                            <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium group-hover:underline">{{ $store->name }}</p>
+                                            <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400">{{ $store->address }}</p>
+                                        </div>
+                                        <svg class="w-5 h-5 text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                        </svg>
                                     </a>
                                 </li>
                             @endforeach
@@ -97,11 +102,17 @@
                         <ul class="space-y-2 sm:space-y-3">
                             @foreach($favoriteInstructors as $instructor)
                                 <li>
-                                    <a href="{{ route('instructors.show', $instructor) }}" class="block hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition">
-                                        <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium">{{ $instructor->name }}</p>
-                                        @if($instructor->instructorProfile?->bio)
-                                            <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400 line-clamp-1">{{ $instructor->instructorProfile->bio }}</p>
-                                        @endif
+                                    <a href="{{ route('instructors.show', $instructor) }}" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
+                                        <span class="pointer-events-none absolute inset-0 group-active:bg-gray-200/30 dark:group-active:bg-white/10 transition"></span>
+                                        <div class="py-1 sm:py-0 flex-1">
+                                            <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium group-hover:underline">{{ $instructor->name }}</p>
+                                            @if($instructor->instructorProfile?->bio)
+                                                <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400 line-clamp-1">{{ $instructor->instructorProfile->bio }}</p>
+                                            @endif
+                                        </div>
+                                        <svg class="w-5 h-5 text-gray-400 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                                        </svg>
                                     </a>
                                 </li>
                             @endforeach

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -31,7 +31,6 @@
                         </li>
                     @endforeach
                 </ul>
-                <div class="mt-4">{{ $reservations->links() }}</div>
             @endif
         </div>
 
@@ -50,7 +49,6 @@
                         </li>
                     @endforeach
                 </ul>
-                <div class="mt-4">{{ $subscriptions->links() }}</div>
             @endif
         </div>
 

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -6,7 +6,7 @@
     </x-slot>
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+        <div data-testid="reservation-history" class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">予約履歴</h3>
                 <a href="{{ route('reservations.history') }}" class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300">すべて表示 →</a>
@@ -35,7 +35,7 @@
             @endif
         </div>
 
-        <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+        <div data-testid="current-subscriptions" class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">契約中のプラン</h3>
                 <a href="{{ route('subscriptions.manage') }}" class="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300">すべて表示 →</a>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -70,7 +70,7 @@
                         <ul class="space-y-2 sm:space-y-3">
                             @foreach($favoriteStores as $store)
                                 <li>
-                                    <a href="{{ route('stores.show', $store) }}" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
+                                    <a href="{{ route('stores.show', $store) }}" aria-label="{{ $store->name }}の詳細を見る" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
                                         <span class="pointer-events-none absolute inset-0 group-active:bg-gray-200/30 dark:group-active:bg-white/10 transition"></span>
                                         <div class="py-1 sm:py-0 flex-1">
                                             <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium group-hover:underline">{{ $store->name }}</p>
@@ -100,7 +100,7 @@
                         <ul class="space-y-2 sm:space-y-3">
                             @foreach($favoriteInstructors as $instructor)
                                 <li>
-                                    <a href="{{ route('instructors.show', $instructor) }}" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
+                                    <a href="{{ route('instructors.show', $instructor) }}" aria-label="{{ $instructor->name }}の詳細を見る" class="group relative flex items-center justify-between p-3 sm:p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 active:scale-[0.99] overflow-hidden">
                                         <span class="pointer-events-none absolute inset-0 group-active:bg-gray-200/30 dark:group-active:bg-white/10 transition"></span>
                                         <div class="py-1 sm:py-0 flex-1">
                                             <p class="text-sm sm:text-base text-gray-900 dark:text-gray-100 font-medium group-hover:underline">{{ $instructor->name }}</p>

--- a/resources/views/subscriptions/manage.blade.php
+++ b/resources/views/subscriptions/manage.blade.php
@@ -1,0 +1,95 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            サブスクリプション管理
+        </h2>
+    </x-slot>
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">契約中のプラン</h3>
+                </div>
+                @if($active->isEmpty())
+                    <p class="text-sm text-gray-600 dark:text-gray-400">契約中のプランはありません。</p>
+                @else
+                    <ul class="space-y-3">
+                        @foreach($active as $sub)
+                            <li class="flex flex-col gap-1 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
+                                <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $sub->plan?->name ?? '未設定' }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">期間: {{ $sub->formatted_period }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">次回支払日:
+                                    @if(!empty($sub->cancel_at_period_end))
+                                        解約のため無し
+                                    @else
+                                        {{ $sub->current_period_end?->format('Y/m/d') ?? '未定' }}
+                                    @endif
+                                </p>
+                                @php
+                                    $status = (string) $sub->status;
+                                    $statusClasses = match ($status) {
+                                        'active', 'trialing' => 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200',
+                                        'past_due' => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200',
+                                        'canceled' => 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+                                        default => 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+                                    };
+                                @endphp
+                                <div class="flex items-center gap-2 mt-1">
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium w-fit {{ $statusClasses }}">
+                                        ステータス: {{ $sub->status_label }}
+                                    </span>
+                                    @if(!empty($sub->cancel_at_period_end))
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium w-fit bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200">
+                                            解約@if(!empty($sub->cancel_at))(有効期限:{{ $sub->cancel_at->format('Y/m/d') }})@endif
+                                        </span>
+                                    @endif
+                                </div>
+                                <form method="POST" action="{{ route('subscriptions.cancel') }}" class="mt-2">
+                                    @csrf
+                                    <input type="hidden" name="subscription_id" value="{{ $sub->id }}">
+                                    <button type="submit" @if(!empty($sub->cancel_at_period_end)) disabled aria-disabled="true" @endif class="inline-flex items-center px-4 py-2 bg-red-600 dark:bg-red-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-700 dark:hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:pointer-events-none transition ease-in-out duration-150">
+                                        解約（期末）
+                                    </button>
+                                </form>
+                            </li>
+                        @endforeach
+                    </ul>
+                    <div class="mt-3">{{ $active->links() }}</div>
+                @endif
+            </div>
+
+            <div class="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.1),0_1px_3px_rgba(0,0,0,0.1)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_3px_rgba(0,0,0,0.3)]">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">過去のプラン</h3>
+                </div>
+                @if($past->isEmpty())
+                    <p class="text-sm text-gray-600 dark:text-gray-400">過去のプランはありません。</p>
+                @else
+                    <ul class="space-y-3">
+                        @foreach($past as $sub)
+                            <li class="flex flex-col gap-1 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50">
+                                <p class="text-gray-900 dark:text-gray-100 font-medium">{{ $sub->plan?->name ?? '未設定' }}</p>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">期間: {{ $sub->formatted_period }}</p>
+                                @php
+                                    $status = (string) $sub->status;
+                                    $statusClasses = match ($status) {
+                                        'active', 'trialing' => 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200',
+                                        'past_due' => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200',
+                                        'canceled' => 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+                                        default => 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+                                    };
+                                @endphp
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium w-fit {{ $statusClasses }}">
+                                    ステータス: {{ $sub->status_label }}
+                                </span>
+                            </li>
+                        @endforeach
+                    </ul>
+                    <div class="mt-3">{{ $past->links() }}</div>
+                @endif
+            </div>
+        </div>
+    </div>
+    @include('layouts.user-footer')
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,26 +1,28 @@
 <?php
 
+use App\Http\Controllers\Admin\GroupReservationController;
 use App\Http\Controllers\Admin\InstructorController;
 use App\Http\Controllers\Admin\LessonCategoryController;
 use App\Http\Controllers\Admin\LessonController;
 use App\Http\Controllers\Admin\LessonScheduleController;
 use App\Http\Controllers\Admin\NotificationTemplateController;
-use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\Admin\PersonalReservationController;
 use App\Http\Controllers\Admin\ReservationController as AdminReservationController;
 use App\Http\Controllers\Admin\SettingController;
 use App\Http\Controllers\Admin\StoreController as AdminStoreController;
-use App\Http\Controllers\Admin\SubscriptionPlanController;
 use App\Http\Controllers\Admin\SubscriptionController as AdminUserSubscriptionController;
-use App\Http\Controllers\Admin\GroupReservationController;
-use App\Http\Controllers\Admin\PersonalReservationController;
-use App\Http\Controllers\HomeController;
-use App\Http\Controllers\StoreController;
-use App\Http\Controllers\InstructorProfileController;
-use App\Http\Controllers\InstructorController as PublicInstructorController;
+use App\Http\Controllers\Admin\SubscriptionPlanController;
+use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\FavoriteController;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\InstructorController as PublicInstructorController;
+use App\Http\Controllers\InstructorProfileController;
+use App\Http\Controllers\PlanController;
 use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\ReservationController;
 use App\Http\Controllers\Reservation\HistoryController as ReservationHistoryController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\StoreController;
+use App\Http\Controllers\Stripe\WebhookController as StripeWebhookController;
 use App\Http\Controllers\SubscriptionController;
 use App\Models\LessonSchedule;
 use Illuminate\Support\Facades\Route;
@@ -106,6 +108,19 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('subscription.success');
     Route::get('/subscription/cancel', [SubscriptionController::class, 'cancel'])
         ->name('subscription.cancel');
+
+    // Subscription manage (Task 48)
+    Route::prefix('subscriptions')->name('subscriptions.')->group(function () {
+        // 管理ページ
+        Route::get('/manage', [\App\Http\Controllers\Subscription\ManageController::class, 'index'])
+            ->name('manage');
+        // プラン切替
+        Route::post('/switch', [\App\Http\Controllers\Subscription\ManageController::class, 'switch'])
+            ->name('switch');
+        // 解約（期末）
+        Route::post('/cancel', [\App\Http\Controllers\Subscription\ManageController::class, 'cancel'])
+            ->name('cancel');
+    });
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::get('/mypage', [ProfileController::class, 'index'])->name('profile.index');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
@@ -117,6 +132,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Reservation history
     Route::get('/reservations/history', [ReservationHistoryController::class, 'index'])->name('reservations.history');
+
+    // Public plans index (user-facing)
+    Route::get('/plans', [PlanController::class, 'index'])->name('plans.index');
 
     // User reservation actions
     Route::post('/lesson-schedules/{lessonSchedule}/reservations', [ReservationController::class, 'store'])
@@ -195,3 +213,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
 });
 
 require __DIR__.'/auth.php';
+
+// Stripe Webhook (no auth, CSRF exempt via route middleware group in bootstrap/app.php or middleware alias)
+Route::post('/stripe/webhook', [StripeWebhookController::class, 'handle'])->name('stripe.webhook');

--- a/tests/Feature/AdditionalStripeStatusLocalizationTest.php
+++ b/tests/Feature/AdditionalStripeStatusLocalizationTest.php
@@ -23,7 +23,7 @@ it('shows Japanese labels for additional statuses', function (): void {
         $sub = UserSubscription::create([
             'user_id' => $user->id,
             'plan_id' => $plan->id,
-            'stripe_subscription_id' => 'sub_'.uniqid(),
+            'stripe_subscription_id' => (string) Str::uuid(),
             'status' => $status,
             'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
             'current_period_start' => now(),

--- a/tests/Feature/AdditionalStripeStatusLocalizationTest.php
+++ b/tests/Feature/AdditionalStripeStatusLocalizationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('shows Japanese labels for additional statuses', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create();
+
+    $statuses = [
+        UserSubscription::STATUS_INCOMPLETE => '未完了',
+        UserSubscription::STATUS_INCOMPLETE_EXPIRED => '未完了（期限切れ）',
+        UserSubscription::STATUS_UNPAID => '未払い',
+        UserSubscription::STATUS_PAUSED => '一時停止',
+        UserSubscription::STATUS_UNKNOWN => '不明',
+    ];
+
+    foreach ($statuses as $status => $label) {
+        $sub = UserSubscription::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'stripe_subscription_id' => 'sub_'.uniqid(),
+            'status' => $status,
+            'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+            'current_period_start' => now(),
+            'current_period_end' => now()->addDay(),
+        ]);
+
+        expect($sub->status_label)->toBe($label);
+    }
+});

--- a/tests/Feature/CancelFlagsPersistedUiTest.php
+++ b/tests/Feature/CancelFlagsPersistedUiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('reflects cancel flags from DB on manage page and simple card', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create();
+    $sub = UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => 'sub_cancel_flag',
+        'status' => UserSubscription::STATUS_ACTIVE,
+        'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+        'current_period_start' => now(),
+        'current_period_end' => now()->addDays(7),
+        'cancel_at_period_end' => true,
+        'cancel_at' => now()->addDays(7),
+    ]);
+
+    // manage page shows 解約(有効期限:...)
+    $this->actingAs($user)
+        ->get(route('subscriptions.manage'))
+        ->assertOk()
+        ->assertSeeText('解約(有効期限:'.now()->addDays(7)->format('Y/m/d').')')
+        ->assertSeeText('解約のため無し');
+
+    // simple card shows 解約のため無し
+    $html = view('components.subscription.simple-card', ['subscription' => $sub])->render();
+    expect($html)->toContain('解約のため無し');
+});

--- a/tests/Feature/PlansIndexTest.php
+++ b/tests/Feature/PlansIndexTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('disables apply button if user already subscribed to the plan', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create([
+        'stripe_price_id' => 'price_abc',
+        'is_active' => true,
+    ]);
+
+    UserSubscription::factory()
+        ->for($user)
+        ->for($plan, 'plan')
+        ->active()
+        ->create([
+            'current_period_end' => now()->addDay(),
+        ]);
+
+    $this->actingAs($user)
+        ->get(route('plans.index'))
+        ->assertOk()
+        ->assertSeeText('申し込み済み')
+        ->assertDontSeeText('申し込む');
+});
+
+it('shows apply link when user not subscribed to the plan', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create([
+        'stripe_price_id' => 'price_xyz',
+        'is_active' => true,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('plans.index'))
+        ->assertOk()
+        ->assertSeeText('申し込む');
+});

--- a/tests/Feature/ProfileMypageOrderTest.php
+++ b/tests/Feature/ProfileMypageOrderTest.php
@@ -22,8 +22,8 @@ it('renders reservation history section before current subscriptions on mypage',
         ->assertOk()
         ->getContent();
 
-    $posHistory = mb_strpos($html, '予約履歴');
-    $posSubs = mb_strpos($html, '契約中のプラン');
+    $posHistory = mb_strpos($html, 'data-testid="reservation-history"');
+    $posSubs = mb_strpos($html, 'data-testid="current-subscriptions"');
 
     expect($posHistory)->toBeLessThan($posSubs);
 });

--- a/tests/Feature/ProfileMypageOrderTest.php
+++ b/tests/Feature/ProfileMypageOrderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\Reservation;
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('renders reservation history section before current subscriptions on mypage', function (): void {
+    $user = User::factory()->create();
+
+    // Seed minimal data for sections to render
+    $plan = SubscriptionPlan::factory()->create();
+    UserSubscription::factory()->for($user)->for($plan, 'plan')->active()->create();
+
+    // create one reservation through factory relations
+    Reservation::factory()->create(['user_id' => $user->id]);
+
+    $html = $this->actingAs($user)->get(route('profile.index'))
+        ->assertOk()
+        ->getContent();
+
+    $posHistory = mb_strpos($html, '予約履歴');
+    $posSubs = mb_strpos($html, '契約中のプラン');
+
+    expect($posHistory)->toBeLessThan($posSubs);
+});

--- a/tests/Feature/SubscriptionCancelActionTest.php
+++ b/tests/Feature/SubscriptionCancelActionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+
+uses(RefreshDatabase::class);
+
+it('validates cancel request requires auth and subscription_id', function (): void {
+    $this->post(route('subscriptions.cancel'))->assertRedirect(route('login'));
+
+    $user = User::factory()->create();
+    $this->actingAs($user)
+        ->post(route('subscriptions.cancel'), [])
+        ->assertSessionHasErrors('subscription_id');
+});
+
+it('returns error when stripe secret not set on cancel', function (): void {
+    Config::set('services.stripe.secret', null);
+
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create();
+    $sub = UserSubscription::factory()->for($user)->for($plan, 'plan')->active()->create();
+
+    $this->actingAs($user)
+        ->post(route('subscriptions.cancel'), ['subscription_id' => $sub->id])
+        ->assertSessionHasErrors('subscription');
+});

--- a/tests/Feature/SubscriptionsManagePageTest.php
+++ b/tests/Feature/SubscriptionsManagePageTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('shows active and past subscriptions in two columns with Japanese status', function (): void {
+    $user = User::factory()->create();
+    $activePlan = SubscriptionPlan::factory()->create();
+    $pastPlan = SubscriptionPlan::factory()->create();
+
+    // Active (paid, period in future)
+    UserSubscription::factory()
+        ->for($user)
+        ->for($activePlan, 'plan')
+        ->active()
+        ->create([
+            'current_period_start' => now()->subDay(),
+            'current_period_end' => now()->addDays(10),
+        ]);
+
+    // Past (canceled)
+    UserSubscription::factory()
+        ->for($user)
+        ->for($pastPlan, 'plan')
+        ->create([
+            'status' => UserSubscription::STATUS_CANCELED,
+            'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+            'current_period_start' => now()->subMonths(2),
+            'current_period_end' => now()->subMonth(),
+        ]);
+
+    $this->actingAs($user)
+        ->get(route('subscriptions.manage'))
+        ->assertOk()
+        ->assertSeeText('契約中のプラン')
+        ->assertSeeText('過去のプラン')
+        ->assertSeeText('ステータス: 有効')
+        ->assertSeeText('ステータス: キャンセル済み');
+});
+
+it('disables cancel button when cancel_at_period_end is true (UI hint)', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create();
+
+    $sub = UserSubscription::factory()->for($user)->for($plan, 'plan')->active()->create([
+        'current_period_end' => now()->addDays(5),
+    ]);
+    // Enrich flags at runtime (not persisted)
+    $sub->cancel_at_period_end = true;
+    $sub->cancel_at = now()->addDays(5);
+
+    // Render view directly to test blade logic with injected flags
+    $active = new \Illuminate\Pagination\LengthAwarePaginator(collect([$sub]), 1, 10);
+    $past = new \Illuminate\Pagination\LengthAwarePaginator(collect(), 0, 10);
+
+    $html = view('subscriptions.manage', compact('active', 'past'))
+        ->render();
+
+    expect($html)->toContain('解約（期末）');
+    expect($html)->toContain('解約(有効期限:'.now()->addDays(5)->format('Y/m/d').')');
+});

--- a/tests/Feature/SubscriptionsSimpleCardComponentTest.php
+++ b/tests/Feature/SubscriptionsSimpleCardComponentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('renders next payment date or none when cancel_at_period_end is set', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create(['lesson_count' => 3]);
+    $sub = UserSubscription::factory()->for($user)->for($plan, 'plan')->active()->create([
+        'current_period_end' => now()->addDays(10),
+    ]);
+
+    // Component render without cancel flags
+    $html1 = view('components.subscription.simple-card', ['subscription' => $sub])->render();
+    expect($html1)->toContain('次回支払日');
+    expect($html1)->toContain(now()->addDays(10)->format('Y年m月d日'));
+
+    // With cancel flags (simulate property enrichment)
+    $sub->cancel_at_period_end = true;
+    $sub->cancel_at = now()->addDays(10);
+
+    $html2 = view('components.subscription.simple-card', ['subscription' => $sub])->render();
+    expect($html2)->toContain('解約のため無し');
+});

--- a/tests/Feature/UserSubscriptionUniqueConstraintTest.php
+++ b/tests/Feature/UserSubscriptionUniqueConstraintTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\SubscriptionPlan;
+use App\Models\User;
+use App\Models\UserSubscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('prevents duplicate user-subscription pairs by unique constraint', function (): void {
+    $user = User::factory()->create();
+    $plan = SubscriptionPlan::factory()->create();
+    $stripeId = 'sub_unique_1';
+
+    UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => $stripeId,
+        'status' => UserSubscription::STATUS_ACTIVE,
+        'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+        'current_period_start' => now(),
+        'current_period_end' => now()->addDay(),
+    ]);
+
+    try {
+        UserSubscription::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'stripe_subscription_id' => $stripeId,
+            'status' => UserSubscription::STATUS_ACTIVE,
+            'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+            'current_period_start' => now(),
+            'current_period_end' => now()->addDay(),
+        ]);
+        expect(true)->toBeFalse();
+    } catch (Throwable $e) {
+        expect(UserSubscription::query()->where('user_id', $user->id)->where('stripe_subscription_id', $stripeId)->count())->toBe(1);
+    }
+});

--- a/tests/Feature/UserSubscriptionUniqueConstraintTest.php
+++ b/tests/Feature/UserSubscriptionUniqueConstraintTest.php
@@ -22,18 +22,19 @@ it('prevents duplicate user-subscription pairs by unique constraint', function (
         'current_period_end' => now()->addDay(),
     ]);
 
-    try {
-        UserSubscription::create([
-            'user_id' => $user->id,
-            'plan_id' => $plan->id,
-            'stripe_subscription_id' => $stripeId,
-            'status' => UserSubscription::STATUS_ACTIVE,
-            'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
-            'current_period_start' => now(),
-            'current_period_end' => now()->addDay(),
-        ]);
-        expect(true)->toBeFalse();
-    } catch (Throwable $e) {
-        expect(UserSubscription::query()->where('user_id', $user->id)->where('stripe_subscription_id', $stripeId)->count())->toBe(1);
-    }
+    expect(fn () => UserSubscription::create([
+        'user_id' => $user->id,
+        'plan_id' => $plan->id,
+        'stripe_subscription_id' => $stripeId,
+        'status' => UserSubscription::STATUS_ACTIVE,
+        'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+        'current_period_start' => now(),
+        'current_period_end' => now()->addDay(),
+    ]))->toThrow(\Illuminate\Database\QueryException::class);
+
+    expect(UserSubscription::query()
+        ->where('user_id', $user->id)
+        ->where('stripe_subscription_id', $stripeId)
+        ->count()
+    )->toBe(1);
 });

--- a/tests/Feature/UserSubscriptionUniqueConstraintTest.php
+++ b/tests/Feature/UserSubscriptionUniqueConstraintTest.php
@@ -22,15 +22,23 @@ it('prevents duplicate user-subscription pairs by unique constraint', function (
         'current_period_end' => now()->addDay(),
     ]);
 
-    expect(fn () => UserSubscription::create([
-        'user_id' => $user->id,
-        'plan_id' => $plan->id,
-        'stripe_subscription_id' => $stripeId,
-        'status' => UserSubscription::STATUS_ACTIVE,
-        'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
-        'current_period_start' => now(),
-        'current_period_end' => now()->addDay(),
-    ]))->toThrow(\Illuminate\Database\QueryException::class);
+    $exception = null;
+    try {
+        UserSubscription::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'stripe_subscription_id' => $stripeId,
+            'status' => UserSubscription::STATUS_ACTIVE,
+            'payment_status' => UserSubscription::PAYMENT_STATUS_PAID,
+            'current_period_start' => now(),
+            'current_period_end' => now()->addDay(),
+        ]);
+    } catch (\Illuminate\Database\QueryException $e) {
+        $exception = $e;
+    }
+
+    expect($exception)->toBeInstanceOf(\Illuminate\Database\QueryException::class);
+    expect($exception->getCode())->toBe('23000'); // Integrity constraint violation
 
     expect(UserSubscription::query()
         ->where('user_id', $user->id)

--- a/tests/Feature/WebhookIdempotencyDbTest.php
+++ b/tests/Feature/WebhookIdempotencyDbTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+it('enforces unique event id in stripe_webhook_events', function (): void {
+    $eventId = 'evt_test_idem_123';
+
+    DB::table('stripe_webhook_events')->insert([
+        'event_id' => $eventId,
+        'type' => 'invoice.payment_succeeded',
+        'payload' => json_encode(['id' => $eventId]),
+        'received_at' => now(),
+    ]);
+
+    try {
+        DB::table('stripe_webhook_events')->insert([
+            'event_id' => $eventId,
+            'type' => 'invoice.payment_succeeded',
+            'payload' => json_encode(['id' => $eventId]),
+            'received_at' => now(),
+        ]);
+        // if no exception thrown, force fail
+        expect(true)->toBeFalse();
+    } catch (Throwable $e) {
+        // expected unique constraint violation
+        expect(DB::table('stripe_webhook_events')->where('event_id', $eventId)->count())->toBe(1);
+    }
+});

--- a/tests/Feature/WebhookIdempotencyDbTest.php
+++ b/tests/Feature/WebhookIdempotencyDbTest.php
@@ -23,7 +23,7 @@ it('enforces unique event id in stripe_webhook_events', function (): void {
             'received_at' => now(),
         ]);
         // if no exception thrown, force fail
-        expect(true)->toBeFalse();
+        $this->fail('Expected unique constraint violation but none was thrown');
     } catch (Throwable $e) {
         // expected unique constraint violation
         expect(DB::table('stripe_webhook_events')->where('event_id', $eventId)->count())->toBe(1);

--- a/tests/Feature/WebhookIdempotencyDbTest.php
+++ b/tests/Feature/WebhookIdempotencyDbTest.php
@@ -15,17 +15,14 @@ it('enforces unique event id in stripe_webhook_events', function (): void {
         'received_at' => now(),
     ]);
 
-    try {
+    expect(function () use ($eventId) {
         DB::table('stripe_webhook_events')->insert([
             'event_id' => $eventId,
             'type' => 'invoice.payment_succeeded',
             'payload' => json_encode(['id' => $eventId]),
             'received_at' => now(),
         ]);
-        // if no exception thrown, force fail
-        $this->fail('Expected unique constraint violation but none was thrown');
-    } catch (Throwable $e) {
-        // expected unique constraint violation
-        expect(DB::table('stripe_webhook_events')->where('event_id', $eventId)->count())->toBe(1);
-    }
+    })->toThrow(\Illuminate\Database\QueryException::class);
+
+    expect(DB::table('stripe_webhook_events')->where('event_id', $eventId)->count())->toBe(1);
 });


### PR DESCRIPTION
- WebhookController::syncSubscriptionById を updateOrCreate に変更
- stripe_subscription_id を検索キーにしてユニーク違反を防止
- cancel_at_period_end / cancel_at を DB に保存して UI と整合
- 関連テストを実行し全テスト通過を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - プラン一覧ページとサブスクリプション管理画面を追加（契約中／過去プラン表示、切替・解約操作、キャンセル予定表示）。
  - Stripeウェブフック受信と同期を導入（冪等化、受信イベント保存と処理）。
  - シンプルなサブスクリプションカードコンポーネントを追加。
  - 切替・解約用のリクエスト検証を追加。

- 改善
  - ステータス表示を拡充し日本語ラベルを追加。
  - ホーム／プロフィールでカード表示に統一、表示件数を一部増加。
  - 切替処理に重複防止ガードを追加。

- 安定性・テスト
  - サブスクリプション関連のマイグレーション（イベント保存用テーブル／取消フラグ等）と一意制約の調整。
  - 関連の自動テスト群とCIワークフローを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->